### PR TITLE
Introduce additional Tags for Project Name (non breaking change)

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -1,22 +1,24 @@
 package jenkinsci.plugins.influxdb.generators;
 
 import hudson.model.Run;
-
-import java.util.List;
+import org.influxdb.dto.Point;
 
 public abstract class AbstractPointGenerator implements  PointGenerator {
 
     public static final String PROJECT_NAME = "project_name";
     public static final String BUILD_NUMBER = "build_number";
 
-    protected void addJenkinsProjectName(Run<?, ?> build, List<String> columnNames, List<Object> values) {
-        columnNames.add(PROJECT_NAME);
-        values.add(build.getParent().getName());
-    }
-
-    protected void addJenkinsBuildNumber(Run<?, ?> build, List<String> columnNames, List<Object> values) {
-        columnNames.add(BUILD_NUMBER);
-        values.add(build.getNumber());
+    @Override
+    public Point.Builder buildPoint(String name, Run<?,?> build) {
+        return Point
+                .measurement(name)
+                .addField(PROJECT_NAME, build
+                        .getParent()
+                        .getName())
+                .addField(BUILD_NUMBER, build.getNumber())
+                .tag(PROJECT_NAME, build
+                        .getParent()
+                        .getName());
     }
 
     protected String measurementName(String measurement) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
@@ -46,10 +46,8 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
 
     public Point[] generate() {
         try {
-            List ls = coberturaFile.act(new CoberturaFileCallable()); 
-            Point point = Point.measurement("cobertura_data")
-                .field(BUILD_NUMBER, build.getNumber())
-                .field(PROJECT_NAME, build.getParent().getName())
+            List ls = coberturaFile.act(new CoberturaFileCallable());
+            Point point = buildPoint("cobertura_data", build)
                 .field(COBERTURA_NUMBER_OF_PACKAGES, ls.get(0))
                 .field(COBERTURA_NUMBER_OF_SOURCEFILES, ls.get(1))
                 .field(COBERTURA_NUMBER_OF_CLASSES, ls.get(2))
@@ -64,6 +62,8 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
         }
         return null;
     }
+
+
 
     private static final class CoberturaFileCallable extends MasterToSlaveFileCallable<List<Number>> {
         private static final long serialVersionUID = 1;

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
@@ -28,9 +28,7 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     }
 
     public Point[] generate() {
-        Point point = Point.measurement(measurementName("jacoco_data"))
-            .field(BUILD_NUMBER, build.getNumber())
-            .field(PROJECT_NAME, build.getParent().getName())
+        Point point = buildPoint(measurementName("jacoco_data"), build)
             .field(JACOCO_INSTRUCTION_COVERAGE_RATE, jacocoBuildAction.getResult().getInstructionCoverage().getPercentageFloat())
             .field(JACOCO_CLASS_COVERAGE_RATE, jacocoBuildAction.getResult().getClassCoverage().getPercentageFloat())
             .field(JACOCO_BRANCH_COVERAGE_RATE, jacocoBuildAction.getResult().getBranchCoverage().getPercentageFloat())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -33,9 +33,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     private Point generatePointWithoutTestResults(long dt) {
-        Point point = Point.measurement(measurementName("jenkins_data"))
-            .field(BUILD_NUMBER, build.getNumber())
-            .field(PROJECT_NAME, build.getParent().getName())
+        Point point = buildPoint(measurementName("jenkins_data"), build)
             .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
@@ -45,9 +43,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     private Point generatePointWithTestResults(long dt) {
-        Point point = Point.measurement(measurementName("jenkins_data"))
-            .field(BUILD_NUMBER, build.getNumber())
-            .field(PROJECT_NAME, build.getParent().getName())
+        Point point = buildPoint(measurementName("jenkins_data"), build)
             .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
@@ -9,4 +9,8 @@ public interface PointGenerator {
 
     public Point[] generate();
 
+    /**
+     * Initializes a basic build point with the basic data already set.
+     */
+    Point.Builder buildPoint(String name, Run<?, ?> build);
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -119,9 +119,7 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     }
 
     private Point generateCasePoint(RobotCaseResult caseResult) {
-        Point point = Point.measurement(measurementName("testcase_point"))
-            .field(BUILD_NUMBER, build.getNumber())
-            .field(PROJECT_NAME, build.getParent().getName())
+        Point point = buildPoint(measurementName("testcase_point"), build)
             .field(RF_NAME, caseResult.getName())
             .field(RF_SUITE_NAME, caseResult.getParent().getName())
             .field(RF_CRITICAL_FAILED, caseResult.getCriticalFailed())
@@ -167,7 +165,7 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     }
 
     private Point generateTagPoint(RobotTagResult tagResult) {
-        Point point = Point.measurement(measurementName("tag_point"))
+        Point point = buildPoint(measurementName("tag_point"), build)
             .field(RF_CRITICAL_FAILED, tagResult.criticalFailed)
             .field(RF_CRITICAL_PASSED, tagResult.criticalPassed)
             .field(RF_CRITICAL_TOTAL, tagResult.criticalPassed + tagResult.criticalFailed)
@@ -181,9 +179,7 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     }
 
     private Point generateSuitePoint(RobotSuiteResult suiteResult) {
-        Point point = Point.measurement(measurementName("suite_result"))
-            .field(BUILD_NUMBER, build.getNumber())
-            .field(PROJECT_NAME, build.getParent().getName())
+        Point point = buildPoint(measurementName("suite_result"), build)
             .field(RF_SUITE_NAME, suiteResult.getName())
             .field(RF_TESTCASES, suiteResult.getAllCases().size())
             .field(RF_CRITICAL_FAILED, suiteResult.getCriticalFailed())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/ZAProxyPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/ZAProxyPointGenerator.java
@@ -1,19 +1,15 @@
 package jenkinsci.plugins.influxdb.generators;
 
-import jenkins.MasterToSlaveFileCallable;
-
-import org.influxdb.dto.Point;
-import org.jdom.JDOMException;
-import org.zaproxy.clientapi.core.Alert;
-import org.zaproxy.clientapi.core.AlertsFile;
-
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+import org.influxdb.dto.Point;
+import org.jdom.JDOMException;
+import org.zaproxy.clientapi.core.AlertsFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.InterruptedException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,12 +39,11 @@ public class ZAProxyPointGenerator extends AbstractPointGenerator {
         return false;
     }
 
+    @Override
     public Point[] generate() {
         try {
             List<Integer> ls = zapFile.act(new ZAPFileCallable());
-            Point point = Point.measurement("zap_data")
-                .field(BUILD_NUMBER, build.getNumber())
-                .field(PROJECT_NAME, build.getParent().getName())
+            Point point = buildPoint("zap_data", build)
                 .field(HIGH_ALERTS, ls.get(0))
                 .field(MEDIUM_ALERTS, ls.get(1))
                 .field(LOW_ALERTS, ls.get(2))


### PR DESCRIPTION
This change allows you to group by project name (which is currently not possible because project name is only a field).
this allows you to load data from one series without the need to use a series per application.
