### PR TITLE
Enable influx custom prefixes

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -1,22 +1,30 @@
 package jenkinsci.plugins.influxdb.generators;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import hudson.model.Run;
 import org.influxdb.dto.Point;
 
-public abstract class AbstractPointGenerator implements  PointGenerator {
+public abstract class AbstractPointGenerator implements PointGenerator {
 
     public static final String PROJECT_NAME = "project_name";
     public static final String BUILD_NUMBER = "build_number";
 
     @Override
-    public Point.Builder buildPoint(String name, Run<?,?> build) {
+    public Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build) {
         return Point
                 .measurement(name)
-                .addField(PROJECT_NAME, build
-                        .getParent()
-                        .getName())
+                .addField(PROJECT_NAME, projectName(customPrefix, build))
                 .addField(BUILD_NUMBER, build.getNumber())
                 .tag(PROJECT_NAME, build
+                        .getParent()
+                        .getName());
+    }
+
+    protected String projectName(String prefix, Run<?, ?> build) {
+        return Joiner
+                .on("_")
+                .join(Strings.emptyToNull(prefix), build
                         .getParent()
                         .getName());
     }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
@@ -20,9 +20,11 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final CoberturaBuildAction coberturaBuildAction;
+    private final String customPrefix;
 
-    public CoberturaPointGenerator(Run<?, ?> build) {
+    public CoberturaPointGenerator(String customPrefix, Run<?, ?> build) {
         this.build = build;
+        this.customPrefix = customPrefix;
         coberturaBuildAction = build.getAction(CoberturaBuildAction.class);
     }
 
@@ -37,7 +39,7 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
         Ratio packages = result.getCoverage(CoverageMetric.PACKAGES);
         Ratio classes = result.getCoverage(CoverageMetric.CLASSES);
         Ratio files = result.getCoverage(CoverageMetric.FILES);
-        Point point = buildPoint("cobertura_data", build)
+        Point point = buildPoint("cobertura_data", customPrefix, build)
             .field(COBERTURA_NUMBER_OF_PACKAGES, packages.denominator)
             .field(COBERTURA_NUMBER_OF_SOURCEFILES, files.denominator)
             .field(COBERTURA_NUMBER_OF_CLASSES, classes.denominator)

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
@@ -15,10 +15,12 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     public static final String JACOCO_INSTRUCTION_COVERAGE_RATE = "jacoco_instruction_coverage_rate";
 
     private final Run<?, ?> build;
+    private final String customPrefix;
     private final JacocoBuildAction jacocoBuildAction;
 
-    public JacocoPointGenerator(Run<?, ?> build) {
+    public JacocoPointGenerator(String customPrefix, Run<?, ?> build) {
         this.build = build;
+        this.customPrefix = customPrefix;
         jacocoBuildAction = build.getAction(JacocoBuildAction.class);
     }
 
@@ -27,7 +29,7 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     }
 
     public Point[] generate() {
-        Point point = buildPoint(measurementName("jacoco_data"), build)
+        Point point = buildPoint(measurementName("jacoco_data"), customPrefix, build)
             .field(JACOCO_INSTRUCTION_COVERAGE_RATE, jacocoBuildAction.getResult().getInstructionCoverage().getPercentageFloat())
             .field(JACOCO_CLASS_COVERAGE_RATE, jacocoBuildAction.getResult().getClassCoverage().getPercentageFloat())
             .field(JACOCO_BRANCH_COVERAGE_RATE, jacocoBuildAction.getResult().getBranchCoverage().getPercentageFloat())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -14,9 +14,11 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String TESTS_TOTAL = "tests_total";
 
     private final Run<?, ?> build;
+    private final String customPrefix;
 
-    public JenkinsBasePointGenerator(Run<?, ?> build) {
+    public JenkinsBasePointGenerator(String customPrefix, Run<?, ?> build) {
         this.build = build;
+        this.customPrefix = customPrefix;
     }
 
     public boolean hasReport() {
@@ -33,7 +35,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     private Point generatePointWithoutTestResults(long dt) {
-        Point point = buildPoint(measurementName("jenkins_data"), build)
+        Point point = buildPoint(measurementName("jenkins_data"), customPrefix, build)
             .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
@@ -43,7 +45,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     private Point generatePointWithTestResults(long dt) {
-        Point point = buildPoint(measurementName("jenkins_data"), build)
+        Point point = buildPoint(measurementName("jenkins_data"), customPrefix , build)
             .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
@@ -12,5 +12,5 @@ public interface PointGenerator {
     /**
      * Initializes a basic build point with the basic data already set.
      */
-    Point.Builder buildPoint(String name, Run<?, ?> build);
+    Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build);
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -29,10 +29,12 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     public static final String RF_TESTCASES = "rf_testcases";
 
     private final Run<?, ?> build;
+    private final String customPrefix;
     private final Map<String, RobotTagResult> tagResults;
 
-    public RobotFrameworkPointGenerator(Run<?, ?> build) {
+    public RobotFrameworkPointGenerator(String customPrefix, Run<?, ?> build) {
         this.build = build;
+        this.customPrefix = customPrefix;
         tagResults = new Hashtable<String, RobotTagResult>();
     }
 
@@ -119,7 +121,7 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     }
 
     private Point generateCasePoint(RobotCaseResult caseResult) {
-        Point point = buildPoint(measurementName("testcase_point"), build)
+        Point point = buildPoint(measurementName("testcase_point"), customPrefix, build)
             .field(RF_NAME, caseResult.getName())
             .field(RF_SUITE_NAME, caseResult.getParent().getName())
             .field(RF_CRITICAL_FAILED, caseResult.getCriticalFailed())
@@ -165,7 +167,7 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     }
 
     private Point generateTagPoint(RobotTagResult tagResult) {
-        Point point = buildPoint(measurementName("tag_point"), build)
+        Point point = buildPoint(measurementName("tag_point"), customPrefix, build)
             .field(RF_CRITICAL_FAILED, tagResult.criticalFailed)
             .field(RF_CRITICAL_PASSED, tagResult.criticalPassed)
             .field(RF_CRITICAL_TOTAL, tagResult.criticalPassed + tagResult.criticalFailed)
@@ -179,7 +181,7 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     }
 
     private Point generateSuitePoint(RobotSuiteResult suiteResult) {
-        Point point = buildPoint(measurementName("suite_result"), build)
+        Point point = buildPoint(measurementName("suite_result"), customPrefix, build)
             .field(RF_SUITE_NAME, suiteResult.getName())
             .field(RF_TESTCASES, suiteResult.getAllCases().size())
             .field(RF_CRITICAL_FAILED, suiteResult.getCriticalFailed())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/ZAProxyPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/ZAProxyPointGenerator.java
@@ -24,9 +24,11 @@ public class ZAProxyPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final FilePath zapFile;
+    private final String customPrefix;
 
-    public ZAProxyPointGenerator(Run<?, ?> build, FilePath workspace) {
+    public ZAProxyPointGenerator(String customPrefix, Run<?, ?> build, FilePath workspace) {
         this.build = build;
+        this.customPrefix = customPrefix;
         zapFile = new FilePath(workspace, ZAP_REPORT_FILE);
     }
 
@@ -43,7 +45,7 @@ public class ZAProxyPointGenerator extends AbstractPointGenerator {
     public Point[] generate() {
         try {
             List<Integer> ls = zapFile.act(new ZAPFileCallable());
-            Point point = buildPoint("zap_data", build)
+            Point point = buildPoint("zap_data", customPrefix, build)
                 .field(HIGH_ALERTS, ls.get(0))
                 .field(MEDIUM_ALERTS, ls.get(1))
                 .field(LOW_ALERTS, ls.get(2))

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
@@ -9,5 +9,13 @@
         </j:forEach>
     </select>
   </f:entry>
-  
+
+  <f:section title="Advanced Settings">
+       <f:advanced>
+          <f:entry title="custom-prefix" field="customPrefix" >
+              <f:textbox name="publisherBinding.customPrefix" value="${publisherBinding.customPrefix}"/>
+          </f:entry>
+       </f:advanced>
+  </f:section>
+
 </j:jelly>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -40,7 +40,7 @@
                           <f:repeatableDeleteButton value="delete target"/>
                         </div>
                       </f:entry>
-             
+
                   </table>
                              
             </f:repeatable>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-customPrefix.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-customPrefix.html
@@ -1,0 +1,1 @@
+A custom prefix, that gets prepended to the job name, for example to prevent several 'master' metrics for different jobs in multi branch pipeline jobs


### PR DESCRIPTION
with this commit, it is possible to define a custom prefix per job.
The problem, for multibranch builds the builds are named after the branch built.
Every Git Repository has a branch 'master' and thus, you have mixed results.

We urgently need this feature and would be happy to have it applied and released rather sooner than later, thanks.
