### PR TITLE
Enable influx custom prefixes

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
@@ -1,5 +1,7 @@
 package jenkinsci.plugins.influxdb.generators;
 
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.influxdb.dto.Point;
 
 import hudson.model.Run;
@@ -20,9 +22,12 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final CoberturaBuildAction coberturaBuildAction;
+    private final String customPrefix;
 
-    public CoberturaPointGenerator(Run<?, ?> build) {
+    public CoberturaPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build) {
+        super(projectNameRenderer);
         this.build = build;
+        this.customPrefix = customPrefix;
         coberturaBuildAction = build.getAction(CoberturaBuildAction.class);
     }
 
@@ -37,7 +42,7 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
         Ratio packages = result.getCoverage(CoverageMetric.PACKAGES);
         Ratio classes = result.getCoverage(CoverageMetric.CLASSES);
         Ratio files = result.getCoverage(CoverageMetric.FILES);
-        Point point = buildPoint("cobertura_data", build)
+        Point point = buildPoint("cobertura_data", customPrefix, build)
             .field(COBERTURA_NUMBER_OF_PACKAGES, packages.denominator)
             .field(COBERTURA_NUMBER_OF_SOURCEFILES, files.denominator)
             .field(COBERTURA_NUMBER_OF_CLASSES, classes.denominator)

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
@@ -1,5 +1,6 @@
 package jenkinsci.plugins.influxdb.generators;
 
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 
 import hudson.model.Run;
@@ -15,10 +16,13 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     public static final String JACOCO_INSTRUCTION_COVERAGE_RATE = "jacoco_instruction_coverage_rate";
 
     private final Run<?, ?> build;
+    private final String customPrefix;
     private final JacocoBuildAction jacocoBuildAction;
 
-    public JacocoPointGenerator(Run<?, ?> build) {
+    public JacocoPointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build) {
+        super(measurementRenderer);
         this.build = build;
+        this.customPrefix = customPrefix;
         jacocoBuildAction = build.getAction(JacocoBuildAction.class);
     }
 
@@ -27,7 +31,7 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     }
 
     public Point[] generate() {
-        Point point = buildPoint(measurementName("jacoco_data"), build)
+        Point point = buildPoint(measurementName("jacoco_data"), customPrefix, build)
             .field(JACOCO_INSTRUCTION_COVERAGE_RATE, jacocoBuildAction.getResult().getInstructionCoverage().getPercentageFloat())
             .field(JACOCO_CLASS_COVERAGE_RATE, jacocoBuildAction.getResult().getClassCoverage().getPercentageFloat())
             .field(JACOCO_BRANCH_COVERAGE_RATE, jacocoBuildAction.getResult().getBranchCoverage().getPercentageFloat())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -2,6 +2,7 @@ package jenkinsci.plugins.influxdb.generators;
 
 import hudson.model.Run;
 import hudson.tasks.test.AbstractTestResultAction;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
@@ -14,9 +15,12 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String TESTS_TOTAL = "tests_total";
 
     private final Run<?, ?> build;
+    private final String customPrefix;
 
-    public JenkinsBasePointGenerator(Run<?, ?> build) {
+    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build) {
+        super(projectNameRenderer);
         this.build = build;
+        this.customPrefix = customPrefix;
     }
 
     public boolean hasReport() {
@@ -33,7 +37,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     private Point generatePointWithoutTestResults(long dt) {
-        Point point = buildPoint(measurementName("jenkins_data"), build)
+        Point point = buildPoint(measurementName("jenkins_data"), customPrefix, build)
             .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
@@ -43,7 +47,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     private Point generatePointWithTestResults(long dt) {
-        Point point = buildPoint(measurementName("jenkins_data"), build)
+        Point point = buildPoint(measurementName("jenkins_data"), customPrefix , build)
             .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
@@ -12,5 +12,5 @@ public interface PointGenerator {
     /**
      * Initializes a basic build point with the basic data already set.
      */
-    Point.Builder buildPoint(String name, Run<?, ?> build);
+    Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build);
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/ZAProxyPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/ZAProxyPointGenerator.java
@@ -4,6 +4,7 @@ import hudson.FilePath;
 import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 import org.jdom.JDOMException;
 import org.zaproxy.clientapi.core.AlertsFile;
@@ -24,9 +25,12 @@ public class ZAProxyPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final FilePath zapFile;
+    private final String customPrefix;
 
-    public ZAProxyPointGenerator(Run<?, ?> build, FilePath workspace) {
+    public ZAProxyPointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build, FilePath workspace) {
+        super(measurementRenderer);
         this.build = build;
+        this.customPrefix = customPrefix;
         zapFile = new FilePath(workspace, ZAP_REPORT_FILE);
     }
 
@@ -43,7 +47,7 @@ public class ZAProxyPointGenerator extends AbstractPointGenerator {
     public Point[] generate() {
         try {
             List<Integer> ls = zapFile.act(new ZAPFileCallable());
-            Point point = buildPoint("zap_data", build)
+            Point point = buildPoint("zap_data", customPrefix, build)
                 .field(HIGH_ALERTS, ls.get(0))
                 .field(MEDIUM_ALERTS, ls.get(1))
                 .field(LOW_ALERTS, ls.get(2))

--- a/src/main/java/jenkinsci/plugins/influxdb/renderer/MeasurementRenderer.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/renderer/MeasurementRenderer.java
@@ -1,0 +1,6 @@
+package jenkinsci.plugins.influxdb.renderer;
+
+public interface MeasurementRenderer<T> {
+
+    String render(T input);
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRenderer.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRenderer.java
@@ -1,0 +1,32 @@
+package jenkinsci.plugins.influxdb.renderer;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import hudson.model.Run;
+
+public class ProjectNameRenderer implements MeasurementRenderer<Run<?, ?>> {
+
+    private String customPrefix;
+
+    public ProjectNameRenderer(String customPrefix) {
+        this.customPrefix = Strings.emptyToNull(customPrefix);
+    }
+
+    @Override
+    public String render(Run<?, ?> input) {
+        return measurementName(projectName(customPrefix, input));
+    }
+
+    protected String projectName(String prefix, Run<?, ?> build) {
+        return Joiner
+                .on("_")
+                .join(Strings.emptyToNull(prefix), build
+                        .getParent()
+                        .getName());
+    }
+
+    protected String measurementName(String measurement) {
+        //influx disallows "-" in measurement names.
+        return measurement.replaceAll("-", "_");
+    }
+}

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
@@ -9,5 +9,13 @@
         </j:forEach>
     </select>
   </f:entry>
-  
+
+  <f:section title="Advanced Settings">
+       <f:advanced>
+          <f:entry title="custom-prefix" field="customPrefix" >
+              <f:textbox name="publisherBinding.customPrefix" value="${publisherBinding.customPrefix}"/>
+          </f:entry>
+       </f:advanced>
+  </f:section>
+
 </j:jelly>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -40,7 +40,7 @@
                           <f:repeatableDeleteButton value="delete target"/>
                         </div>
                       </f:entry>
-             
+
                   </table>
                              
             </f:repeatable>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-customPrefix.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-customPrefix.html
@@ -1,0 +1,1 @@
+A custom prefix, that gets prepended to the job name, for example to prevent several 'master' metrics for different jobs in multi branch pipeline jobs


### PR DESCRIPTION
with this commit, it is possible to define a custom prefix per job.
The problem, for multibranch builds the builds are named after the branch built.

This feature would be really nice, as we need it urgently, so please consider applying it and doing a release?
