### PR TITLE
Adding custom data to InfluxDB from pipelines & fixing issue with customPrefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ target/
 pom.xml.releaseBackup
 work/
 release.properties
-.idea/
-*.iml
-

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 pom.xml.releaseBackup
 work/
 release.properties
+.idea/
+*.iml
+

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -100,6 +100,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         return customPrefix;
     }
 
+    @DataBoundSetter
     public void setCustomPrefix(String customPrefix) {
         this.customPrefix = customPrefix;
     }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -1,0 +1,39 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import hudson.model.Run;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import org.influxdb.dto.Point;
+
+import java.util.Map;
+
+public class CustomDataPointGenerator extends AbstractPointGenerator {
+
+    public static final String BUILD_TIME = "build_time";
+
+    private final Run<?, ?> build;
+    private final String customPrefix;
+    Map<String, Object> customData;
+
+    public CustomDataPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map customData) {
+        super(projectNameRenderer);
+        this.build = build;
+        this.customPrefix = customPrefix;
+        this.customData = customData;
+    }
+
+    public boolean hasReport() {
+        return (customData != null && customData.size() > 0);
+    }
+
+    public Point[] generate() {
+        long startTime = build.getTimeInMillis();
+        long currTime = System.currentTimeMillis();
+        long dt = currTime - startTime;
+        Point point = buildPoint(measurementName("jenkins_custom_data"), customPrefix, build)
+                .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
+                .fields(customData)
+                .build();
+        return new Point[] {point};
+    }
+
+}


### PR DESCRIPTION
This pull request is intended to add some flexibility to the plugin.

Data within pipelines can be simply created.
With the CustomDataPointGenerator this can easily be written into Influx as "jenkins_custom_data"
In a pipeline script data is passed as Map to customData as follows:

```
def myDataMap = [:]
myDataMap['myFirstKey'] = 'myValue'
myDataMap['mySecondKey'] = 1234
step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData:myDataMap])
```

The second part of the pull request is to fix an issue with customPrefix. Without `@DataBoundSetter` the customPrefix is not taken into consideration from a pipeline script.
