### PR TITLE
Adding custom data maps to InfluxDB from pipelines

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -73,7 +73,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      * custom data maps, especially in pipelines, where additional information is calculated
      * or retrieved by Groovy functions which should be sent to InfluxDB.
      *
-     * This goes beyond customData since it allows to define multiple customData measurement
+     * This goes beyond customData since it allows to define multiple customData measurements
      * where the name of the measurement is defined as the key of the customDataMap.
      *
      * Example for a pipeline script:
@@ -81,11 +81,12 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      *   def myDataMap1 = [:]
      *   def myDataMap2 = [:]
      *   def myCustomDataMap = [:]
-     *   myDataMap1.myMap1Key1 = 'first value of first map'
-     *   myDataMap1.myMap1Key2 = 'second value of first map'
-     *   myDataMap2.myMap2Key1 = 'first value of second map'
-     *   myCustomDataMap.series1 = myDataMap1
-     *   myCustomDataMap.series2 = myDataMap2
+     *   myDataMap1["myMap1Key1"] = 11 //first value of first map
+     *   myDataMap1["myMap1Key2"] = 12 //second value of first map
+     *   myDataMap2["myMap2Key1"] = 21 //first value of second map
+     *   myDataMap2["myMap2Key2"] = 22 //second value of second map
+     *   myCustomDataMap["series1"] = myDataMap1
+     *   myCustomDataMap["series2"] = myDataMap2
      *   step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customDataMap: myCustomDataMap])
      *
      */

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -4,8 +4,7 @@ import hudson.model.Run;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class CustomDataMapPointGenerator extends AbstractPointGenerator {
 
@@ -13,32 +12,29 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
-    Map<String, Object> customDataMap;
+    Map<String, Map<String, Object>> customDataMap;
 
-    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map CustomDataMap) {
+    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map customDataMap) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
-        this.customDataMap = CustomDataMap;
+        this.customDataMap = customDataMap;
     }
 
     public boolean hasReport() {
         return (customDataMap != null && customDataMap.size() > 0);
     }
 
-    public Map<String, Point[]> generate() {
-        long startTime = build.getTimeInMillis();
-        long currTime = System.currentTimeMillis();
-        long dt = currTime - startTime;
-        Map<String, Point[]> customPoints = new HashMap<String, Point[]>;
-        while (customDataMap.keySet().iterator().hasNext() {
-            String key = customDataMap.keySet().iterator().next();
-            Point point = buildPoint(measurementName(key, customPrefix, build)
+    public Point[] generate() {
+        List<Point> customPoints = new ArrayList<Point>();
+        Set<String> customKeys = customDataMap.keySet();
+        for (String key : customKeys) {
+            Point point = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key))
                     .build();
-            customPoints.put(customDataMap.keySet().iterator().next(), customDataMap.get())
+            customPoints.add(point);
         }
-        return new Point[] {point};
+        return customPoints.toArray(new Point[customPoints.size()]);
     }
 
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -1,0 +1,44 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import hudson.model.Run;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import org.influxdb.dto.Point;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomDataMapPointGenerator extends AbstractPointGenerator {
+
+    public static final String BUILD_TIME = "build_time";
+
+    private final Run<?, ?> build;
+    private final String customPrefix;
+    Map<String, Object> customDataMap;
+
+    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map CustomDataMap) {
+        super(projectNameRenderer);
+        this.build = build;
+        this.customPrefix = customPrefix;
+        this.customDataMap = CustomDataMap;
+    }
+
+    public boolean hasReport() {
+        return (customDataMap != null && customDataMap.size() > 0);
+    }
+
+    public Map<String, Point[]> generate() {
+        long startTime = build.getTimeInMillis();
+        long currTime = System.currentTimeMillis();
+        long dt = currTime - startTime;
+        Map<String, Point[]> customPoints = new HashMap<String, Point[]>;
+        while (customDataMap.keySet().iterator().hasNext() {
+            String key = customDataMap.keySet().iterator().next();
+            Point point = buildPoint(measurementName(key, customPrefix, build)
+                    .fields(customDataMap.get(key))
+                    .build();
+            customPoints.put(customDataMap.keySet().iterator().next(), customDataMap.get())
+        }
+        return new Point[] {point};
+    }
+
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -1,0 +1,86 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.influxdb.dto.Point;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.*;
+
+public class CustomDataMapPointGeneratorTest {
+
+    public static final String JOB_NAME = "master";
+    public static final int BUILD_NUMBER = 11;
+    public static final String CUSTOM_PREFIX = "test_prefix";
+
+    private Run<?,?> build;
+    private Job job;
+
+    private MeasurementRenderer<Run<?, ?>> measurementRenderer;
+
+    @Before
+    public void before() {
+        build = Mockito.mock(Run.class);
+        job = Mockito.mock(Job.class);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX);
+
+        Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
+        Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+
+    }
+
+    @Test
+    public void hasReportTest() {
+        //check with customDataMap = null
+        CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null);
+        Assert.assertFalse(cdmGen1.hasReport());
+
+        //check with empty customDataMap
+        CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap());
+        Assert.assertFalse(cdmGen2.hasReport());
+    }
+
+    @Test
+    public void generateTest() {
+
+        Map<String, Object> customData1 = new HashMap<String, Object>();
+        customData1.put("test1", 11);
+        customData1.put("test2", 22);
+
+
+        Map<String, Object> customData2 = new HashMap<String, Object>();
+        customData2.put("test3", 33);
+        customData2.put("test4", 44);
+
+
+        Map<String, Map<String, Object>> customDataMap = new HashMap<String, Map<String, Object>>();
+        customDataMap.put("series1", customData1);
+        customDataMap.put("series2", customData2);
+
+
+        List<Point> pointsToWrite = new ArrayList<Point>();
+
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customDataMap);
+        pointsToWrite.addAll(Arrays.asList(cdmGen.generate()));
+
+        String lineProtocol1;
+        String lineProtocol2;
+        if (pointsToWrite.get(0).lineProtocol().startsWith("series1"))  {
+            lineProtocol1 = pointsToWrite.get(0).lineProtocol();
+            lineProtocol2 = pointsToWrite.get(1).lineProtocol();
+        } else {
+            lineProtocol1 = pointsToWrite.get(1).lineProtocol();
+            lineProtocol2 = pointsToWrite.get(0).lineProtocol();
+        }
+        Assert.assertTrue(lineProtocol1.startsWith("series1,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
+        Assert.assertTrue(lineProtocol2.startsWith("series2,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -1,6 +1,5 @@
 package jenkinsci.plugins.influxdb.generators;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.Run;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
@@ -9,7 +8,6 @@ import org.influxdb.dto.Point;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.*;

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -58,7 +58,7 @@ public class CustomDataPointGeneratorTest {
         CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData);
         pointsToWrite.addAll(Arrays.asList(cdGen.generate()));
 
-        String lineProtocol = pointsToWrite.get(0).lineProtocol();System.out.println(lineProtocol);
+        String lineProtocol = pointsToWrite.get(0).lineProtocol();
         Assert.assertTrue(lineProtocol.startsWith("jenkins_custom_data,project_name=test_prefix_master build_number=11i,build_time="));
         Assert.assertTrue(lineProtocol.indexOf("project_name=\"test_prefix_master\",test1=11i,test2=22i")>0);
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -1,0 +1,65 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.influxdb.dto.Point;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.*;
+
+public class CustomDataPointGeneratorTest {
+
+    public static final String JOB_NAME = "master";
+    public static final int BUILD_NUMBER = 11;
+    public static final String CUSTOM_PREFIX = "test_prefix";
+
+    private Run<?,?> build;
+    private Job job;
+
+    private MeasurementRenderer<Run<?, ?>> measurementRenderer;
+
+    @Before
+    public void before() {
+        build = Mockito.mock(Run.class);
+        job = Mockito.mock(Job.class);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX);
+
+        Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
+        Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+
+    }
+
+    @Test
+    public void hasReportTest() {
+        //check with customDataMap = null
+        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null);
+        Assert.assertFalse(cdGen1.hasReport());
+
+        //check with empty customDataMap
+        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap());
+        Assert.assertFalse(cdGen2.hasReport());
+    }
+
+    @Test
+    public void generateTest() {
+
+        Map<String, Object> customData = new HashMap<String, Object>();
+        customData.put("test1", 11);
+        customData.put("test2", 22);
+
+        List<Point> pointsToWrite = new ArrayList<Point>();
+
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData);
+        pointsToWrite.addAll(Arrays.asList(cdGen.generate()));
+
+        String lineProtocol = pointsToWrite.get(0).lineProtocol();System.out.println(lineProtocol);
+        Assert.assertTrue(lineProtocol.startsWith("jenkins_custom_data,project_name=test_prefix_master build_number=11i,build_time="));
+        Assert.assertTrue(lineProtocol.indexOf("project_name=\"test_prefix_master\",test1=11i,test2=22i")>0);
+    }
+}


### PR DESCRIPTION
extending what has been provided with #7.

With the CustomDataMapPointGenerator data generated in a pipeline can easily be written into Influx. 
The measurement name is be defined as key of the respective map which itself contains another map with key-value pairs containing measurement data.

Example (also available as comment in InfluxDbPublisher):

    def myDataMap1 = [:]
    def myDataMap2 = [:]
    def myCustomDataMap = [:]
    myDataMap1["myMap1Key1"] = 11 //first value of first map
    myDataMap1["myMap1Key2"] = 12 //second value of first map
    myDataMap2["myMap2Key1"] = 21 //first value of second map
    myDataMap2["myMap2Key2"] = 22 //second value of second map
    myCustomDataMap["series1"] = myDataMap1
    myCustomDataMap["series2"] = myDataMap2
    step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customDataMap: myCustomDataMap])

This pull request also provides unit tests for both customDataPointGenerator as well as customDataMapPointGenerator.