### PR TITLE
Added new build result fields and last stable and successful build numbers

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -9,7 +9,21 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     public static final String BUILD_TIME = "build_time";
     public static final String BUILD_STATUS_MESSAGE = "build_status_message";
+
+    /* BUILD_RESULT BUILD_RESULT_ORDINAL BUILD_IS_SUCCESSFUL - explanation
+     * SUCCESS   0 true  - The build had no errors.
+     * UNSTABLE  1 true  - The build hadsome errors but they were not fatal. For example, some tests failed.
+     * FAILURE   2 false - The build had a fatal error.
+     * NOT_BUILT 3 false - The module was not built.
+     * ABORTED   4 false - The build was manually aborted.
+     */
+    public static final String BUILD_RESULT = "build_result";
+    public static final String BUILD_RESULT_ORDINAL = "build_result_ordinal";
+    public static final String BUILD_IS_SUCCESSFUL = "build_successful";
+
     public static final String PROJECT_BUILD_HEALTH = "project_build_health";
+    public static final String PROJECT_LAST_SUCCESSFUL = "last_successful_build";
+    public static final String PROJECT_LAST_STABLE = "last_stable_build";
     public static final String TESTS_FAILED = "tests_failed";
     public static final String TESTS_SKIPPED = "tests_skipped";
     public static final String TESTS_TOTAL = "tests_total";
@@ -28,39 +42,46 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     }
 
     public Point[] generate() {
-        boolean results = hasTestResults(build);
         // Build is not finished when running with pipelines. Duration must be calculated manually
         long startTime = build.getTimeInMillis();
         long currTime = System.currentTimeMillis();
         long dt = currTime - startTime;
-        Point point = (results) ? generatePointWithTestResults(dt) : generatePointWithoutTestResults(dt);
-        return new Point[] {point};
-    }
 
-    private Point generatePointWithoutTestResults(long dt) {
-        Point point = buildPoint(measurementName("jenkins_data"), customPrefix, build)
-            .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
+        Point.Builder point = buildPoint(measurementName("jenkins_data"), customPrefix, build);
+
+        point.field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
+            .field(BUILD_RESULT, build.getResult().toString())
+            .field(BUILD_RESULT_ORDINAL, build.getResult().ordinal)
+            .field(BUILD_IS_SUCCESSFUL, build.getResult().ordinal < 2 ? true : false)
             .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
-            .build();
+            .field(PROJECT_LAST_SUCCESSFUL, getLastSuccessfulBuild())
+            .field(PROJECT_LAST_STABLE, getLastStableBuild());
 
-        return point;
-    }
+        if(hasTestResults(build)) {
+            point.field(TESTS_FAILED, build.getAction(AbstractTestResultAction.class).getFailCount());
+            point.field(TESTS_SKIPPED, build.getAction(AbstractTestResultAction.class).getSkipCount());
+            point.field(TESTS_TOTAL, build.getAction(AbstractTestResultAction.class).getTotalCount());
+        }
 
-    private Point generatePointWithTestResults(long dt) {
-        Point point = buildPoint(measurementName("jenkins_data"), customPrefix , build)
-            .field(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
-            .field(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
-            .field(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
-            .field(TESTS_FAILED, build.getAction(AbstractTestResultAction.class).getFailCount())
-            .field(TESTS_SKIPPED, build.getAction(AbstractTestResultAction.class).getSkipCount())
-            .field(TESTS_TOTAL, build.getAction(AbstractTestResultAction.class).getTotalCount())
-            .build();
-
-        return point;
+        return new Point[] {point.build()};
     }
 
     private boolean hasTestResults(Run<?, ?> build) {
         return build.getAction(AbstractTestResultAction.class) != null;
+    }
+
+    private int getLastSuccessfulBuild() {
+        if (build.getParent().getLastSuccessfulBuild() != null)
+            return build.getParent().getLastSuccessfulBuild().getNumber();
+        else
+            return 0;
+    }
+
+    private int getLastStableBuild() {
+        if (build.getParent().getLastStableBuild() != null)
+            return build.getParent().getLastStableBuild().getNumber();
+        else
+            return 0;
     }
 }


### PR DESCRIPTION
New fields in jenkins_data:
build_result: SUCCESS, UNSTABLE, FAILURE, NOT_BUILT, ABORTED
build_result_ordinal:  0:(SUCCESS), 1 (UNSTABLE), 2 (FAILURE), 3 (NOT_BUILT), 4 (ABORTED)
build_successful: true if build_result_ordinal < 2
last_stable_build: last stable build, 0 if never
last_successful_build: last successful build, 0 if never
