### PR TITLE
Update Default Rentention Policy Name

### DIFF
--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -32,7 +32,7 @@
                       </f:entry>
 
                       <f:entry title="retentionPolicy" field="retentionPolicy" >
-                         <f:textbox name="targetBinding.retentionPolicy" value="${currentTarget.retentionPolicy}" default="default" />
+                         <f:textbox name="targetBinding.retentionPolicy" value="${currentTarget.retentionPolicy}" default="autogen" />
                       </f:entry>
 
                       <f:entry title="exposeExceptions" field="exposeExceptions" >


### PR DESCRIPTION
Since 1.0, InfluxDB has changed the name of the default retention
policy from 'default' to 'autogen' to reduce naming confusion. This
should be reflected in the default settings for this project.

https://github.com/influxdata/influxdb/pull/6586