### PR TITLE
Fix for calling InfluxDBFactory with a blank or missing username.

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -196,7 +196,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         listener.getLogger().println(logMessage);
 
         // connect to InfluxDB
-        InfluxDB influxDB = InfluxDBFactory.connect(target.getUrl(), target.getUsername(), target.getPassword());
+        InfluxDB influxDB = Strings.isNullOrEmpty(target.getUsername()) ? InfluxDBFactory.connect(target.getUrl()) : InfluxDBFactory.connect(target.getUrl(), target.getUsername(), target.getPassword());
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         // finally write to InfluxDB


### PR DESCRIPTION
Hi,

The plugin currently throws a RuntimeException if a blank username is used, as it calls the wrong factory function in InfluxDBFactory.

This change fixes that.