### PR TITLE
Allow to use Jenkins global proxy when connecting to Influx server

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -13,11 +13,13 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import jenkinsci.plugins.influxdb.generators.*;
 import jenkinsci.plugins.influxdb.models.Target;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import okhttp3.*;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDB.ConsistencyLevel;
 import org.influxdb.InfluxDBFactory;
@@ -195,8 +197,14 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         // write to jenkins console
         listener.getLogger().println(logMessage);
 
+        // use proxy if checked
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        if (target.isUsingJenkinsProxy()) {
+            builder.proxy(Jenkins.getInstance().proxy.createProxy(target.getUrl()));
+        }
+
         // connect to InfluxDB
-        InfluxDB influxDB = Strings.isNullOrEmpty(target.getUsername()) ? InfluxDBFactory.connect(target.getUrl()) : InfluxDBFactory.connect(target.getUrl(), target.getUsername(), target.getPassword());
+        InfluxDB influxDB = Strings.isNullOrEmpty(target.getUsername()) ? InfluxDBFactory.connect(target.getUrl(), builder) : InfluxDBFactory.connect(target.getUrl(), target.getUsername(), target.getPassword(), builder);
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         // finally write to InfluxDB

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -9,6 +9,7 @@ public class Target {
     String database;
     String retentionPolicy;
     boolean exposeExceptions;
+    boolean usingJenkinsProxy;
 
     public Target(){
         //nop
@@ -68,6 +69,14 @@ public class Target {
 
     public void setExposeExceptions(boolean exposeExceptions) {
         this.exposeExceptions = exposeExceptions;
+    }
+
+    public boolean isUsingJenkinsProxy() {
+        return usingJenkinsProxy;
+    }
+
+    public void setUsingJenkinsProxy(boolean usingJenkinsProxy) {
+        this.usingJenkinsProxy = usingJenkinsProxy;
     }
 
     @Override

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -39,6 +39,10 @@
                          <f:checkbox name="targetBinding.exposeExceptions" checked="${currentTarget.exposeExceptions}" default="true" />
                       </f:entry>
 
+                      <f:entry title="Use Jenkins Proxy" field="usingJenkinsProxy" >
+                         <f:checkbox name="targetBinding.usingJenkinsProxy" checked="${currentTarget.usingJenkinsProxy}" default="false" />
+                      </f:entry>
+
                       <f:entry title="delete target" >
                         <div align="right">
                           <f:repeatableDeleteButton value="delete target"/>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-usingJenkinsProxy.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-usingJenkinsProxy.html
@@ -1,0 +1,1 @@
+Use the global Jenkins proxy configuration when connecting to this server.


### PR DESCRIPTION
Now, during setting new connectivity to InfluxDB it is able to use proxy from Jenkins.