### PR TITLE
Add support for customProjectName property to override default project name

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -46,6 +46,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     private String selectedTarget;
 
     /**
+     * custom project name, overrides the project name with the specified value
+     */
+    private String customProjectName;
+
+    /**
      * custom prefix, for example in multi branch pipelines, where every build is named
      * after the branch built and thus you have different builds called 'master' that report
      * different metrics.
@@ -114,6 +119,15 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         this.selectedTarget = target;
     }
 
+    public String getCustomProjectName() {
+        return customProjectName;
+    }
+
+    @DataBoundSetter
+    public void setCustomProjectName(String customProjectName) {
+        this.customProjectName = customProjectName;
+    }    
+
     public String getCustomPrefix() {
         return customPrefix;
     }
@@ -179,7 +193,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
 
-        MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix);
+        MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
 
         // get the target from the job's config
         Target target = getTarget();

--- a/src/main/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRenderer.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRenderer.java
@@ -7,23 +7,26 @@ import hudson.model.Run;
 public class ProjectNameRenderer implements MeasurementRenderer<Run<?, ?>> {
 
     private String customPrefix;
+    private String customProjectName;
 
-    public ProjectNameRenderer(String customPrefix) {
+    public ProjectNameRenderer(String customPrefix, String customProjectName) {
         this.customPrefix = Strings.emptyToNull(customPrefix);
+        this.customProjectName = Strings.emptyToNull(customProjectName);
     }
 
     @Override
     public String render(Run<?, ?> input) {
-        return measurementName(projectName(customPrefix, input));
+        return measurementName(projectName(customPrefix, customProjectName, input));
     }
 
-    protected String projectName(String prefix, Run<?, ?> build) {
+    protected String projectName(String prefix, String projectName, Run<?, ?> build) {
+        if (this.customProjectName == null) {
+           this.customProjectName = build.getParent().getName();
+        }
         return Joiner
                 .on("_")
                 .skipNulls()
-                .join(Strings.emptyToNull(prefix), build
-                        .getParent()
-                        .getName());
+                .join(Strings.emptyToNull(prefix), Strings.emptyToNull(this.customProjectName));
     }
 
     protected String measurementName(String measurement) {

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
@@ -15,6 +15,9 @@
           <f:entry title="custom-prefix" field="customPrefix" >
               <f:textbox name="publisherBinding.customPrefix" value="${publisherBinding.customPrefix}"/>
           </f:entry>
+          <f:entry title="custom-project-name" field="customProjectName" >
+              <f:textbox name="publisherBinding.customProjectName" value="${publisherBinding.customProjectName}"/>
+          </f:entry>
        </f:advanced>
   </f:section>
 

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-customProjectName.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-customProjectName.html
@@ -1,0 +1,1 @@
+Sets a custom value for the InfluxDB 'project_name' tagKey, that overrides the default, which is the job name. Useful to easily group metrics for different jobs in multi branch pipeline jobs.

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -27,7 +27,7 @@ public class CustomDataMapPointGeneratorTest {
     public void before() {
         build = Mockito.mock(Run.class);
         job = Mockito.mock(Job.class);
-        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
 
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getParent()).thenReturn(job);

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -27,7 +27,7 @@ public class CustomDataPointGeneratorTest {
     public void before() {
         build = Mockito.mock(Run.class);
         job = Mockito.mock(Job.class);
-        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
 
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getParent()).thenReturn(job);

--- a/src/test/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRendererTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRendererTest.java
@@ -1,0 +1,59 @@
+package jenkinsci.plugins.influxdb.renderer;
+
+import hudson.model.Job;
+import hudson.model.Run;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ProjectNameRendererTest {
+
+    public static final String JOB_NAME = "master";
+    public static final int BUILD_NUMBER = 11;
+    public static final String CUSTOM_PREFIX = "test_prefix";
+    public static final String CUSTOM_PROJECT_NAME = "test_projectname";
+
+    private Run<?,?> build;
+    private Job job;
+
+
+    @Before
+    public void before() {
+        build = Mockito.mock(Run.class);
+        job = Mockito.mock(Job.class);
+
+        Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
+        Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+
+    }
+
+    @Test
+    public void customProjectNameWithCustomPrefixTest() {
+        ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, CUSTOM_PROJECT_NAME);
+        String renderedProjectName = projectNameRenderer.render(build);
+        Assert.assertTrue(renderedProjectName.startsWith("test_prefix_test_projectname"));
+    }
+
+    @Test
+    public void customProjectNameWithNullPrefixTest() {
+        ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(null, CUSTOM_PROJECT_NAME);
+        String renderedProjectName = projectNameRenderer.render(build);
+        Assert.assertTrue(renderedProjectName.startsWith("test_projectname"));
+    }
+
+    @Test
+    public void nullProjectNameWithCustomPrefixTest() {
+        ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
+        String renderedProjectName = projectNameRenderer.render(build);
+        Assert.assertTrue(renderedProjectName.startsWith("test_prefix_master"));
+    }
+
+    @Test
+    public void nullProjectNameWithNullPrefixTest() {
+        ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(null, null);
+        String renderedProjectName = projectNameRenderer.render(build);
+        Assert.assertTrue(renderedProjectName.startsWith("master"));
+    }
+}


### PR DESCRIPTION
In our use case, the default project name value is making it difficult to distinguish various projects across different teams, especially PR builds. This allows a property to be specified that sets the project name value to something other than build.getParent().getName()