### PR TITLE
Fix Job hanging when one of optional dependancy plugins are not installed

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -204,7 +204,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         addPoints(pointsToWrite, jGen, listener);
 
         CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData);
-         if (cdGen.hasReport()) {
+        if (cdGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);
         }
@@ -215,11 +215,13 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             addPoints(pointsToWrite, cdmGen, listener);
         }
 
-        CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build);
-        if (cGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, cGen, listener);
-        }
+        try {
+            CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build);
+            if (cGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, cGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) { }
 
         RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build);
         if (rfGen.hasReport()) {
@@ -227,41 +229,45 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             addPoints(pointsToWrite, rfGen, listener);
         }
 
-        JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build);
-        if (jacoGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, jacoGen, listener);
-        }
+        try {
+            JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build);
+            if (jacoGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, jacoGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) { }
 
-        PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build);
-        if (perfGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, perfGen, listener);
-        }
+        try {
+            PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build);
+            if (perfGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, perfGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) { }
 
-        
         SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build);
         if (sonarGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, sonarGen, listener);
         }
-        
-        
+
+
         ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build);
         if (changeLogGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, changeLogGen, listener);
         }
 
-        PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build);
-        if (perfPublisherGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, perfPublisherGen, listener);
-        }
+        try {
+            PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build);
+            if (perfPublisherGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, perfPublisherGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) { }
 
         writeToInflux(target, influxDB, pointsToWrite);
         listener.getLogger().println("[InfluxDB Plugin] Completed.");
-
     }
 
     private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -221,7 +221,9 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, cGen, listener);
             }
-        } catch (NoClassDefFoundError ignore) { }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Cobertura");
+        }
 
         RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build);
         if (rfGen.hasReport()) {
@@ -235,7 +237,9 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, jacoGen, listener);
             }
-        } catch (NoClassDefFoundError ignore) { }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: JaCoCo");
+        }
 
         try {
             PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build);
@@ -243,7 +247,9 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, perfGen, listener);
             }
-        } catch (NoClassDefFoundError ignore) { }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Performance");
+        }
 
         SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build);
         if (sonarGen.hasReport()) {
@@ -264,7 +270,9 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, perfPublisherGen, listener);
             }
-        } catch (NoClassDefFoundError ignore) { }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Performance Publisher");
+        }
 
         writeToInflux(target, influxDB, pointsToWrite);
         listener.getLogger().println("[InfluxDB Plugin] Completed.");


### PR DESCRIPTION
I have tried using InfluxDB Plugin with Pipeline job, and noticed that whenever we are missing one of the following optional plugins installed: Cobertura, JaCoCo, Performance and Performance Publisher - we will encounter `NoClassDefFoundError` (which is not thrown to console or log), and Job will hang indefinitely 

```
[InfluxDB Plugin] Publishing data to: [url=http://xx.xx.xx.xx:8086, description=test-executions, username=, password=*****, database=test-executions]
[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...
```

At this point. I suggest handle `NoClassDefFoundError` and just ignore it because plugins above are optional

PS. After these plugins are installed, and Jenkins restarted, `NoClassDefFoundError` goes away