### PR TITLE
Sending metrics for all builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.13.1</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.13.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.13.2</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.13.2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.14</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.14</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.13.2</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.13.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14</version>
+    <version>1.15-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.13.1</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.13.1</tag>
     </scm>
 
     <properties>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -1,0 +1,230 @@
+package jenkinsci.plugins.influxdb;
+
+import com.google.common.base.Strings;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkinsci.plugins.influxdb.generators.*;
+import jenkinsci.plugins.influxdb.models.Target;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDB.ConsistencyLevel;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class InfluxDbPublicationService {
+
+    /**
+     * The logger.
+     **/
+    private static final Logger logger = Logger.getLogger(InfluxDbPublicationService.class.getName());
+
+    /**
+     * List of targets to write to
+     */
+    private List<Target> selectedTargets;
+
+    /**
+     * custom project name, overrides the project name with the specified value
+     */
+    private String customProjectName;
+
+    /**
+     * custom prefix, for example in multi branch pipelines, where every build is named
+     * after the branch built and thus you have different builds called 'master' that report
+     * different metrics.
+     */
+    private String customPrefix;
+
+
+    /**
+     * custom data, especially in pipelines, where additional information is calculated
+     * or retrieved by Groovy functions which should be sent to InfluxDB
+     * This can easily be done by calling
+     * <p>
+     * def myDataMap = [:]+
+     * myDataMap['myKey'] = 'myValue'
+     * step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData: myDataMap])
+     * <p>
+     * inside a pipeline script
+     */
+    private Map<String, Object> customData;
+
+    /**
+     * custom data maps, especially in pipelines, where additional information is calculated
+     * or retrieved by Groovy functions which should be sent to InfluxDB.
+     * <p>
+     * This goes beyond customData since it allows to define multiple customData measurements
+     * where the name of the measurement is defined as the key of the customDataMap.
+     * <p>
+     * Example for a pipeline script:
+     * <p>
+     * def myDataMap1 = [:]
+     * def myDataMap2 = [:]
+     * def myCustomDataMap = [:]
+     * myDataMap1["myMap1Key1"] = 11 //first value of first map
+     * myDataMap1["myMap1Key2"] = 12 //second value of first map
+     * myDataMap2["myMap2Key1"] = 21 //first value of second map
+     * myDataMap2["myMap2Key2"] = 22 //second value of second map
+     * myCustomDataMap["series1"] = myDataMap1
+     * myCustomDataMap["series2"] = myDataMap2
+     * step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customDataMap: myCustomDataMap])
+     */
+    private Map<String, Map<String, Object>> customDataMap;
+
+    public InfluxDbPublicationService(List<Target> selectedTargets, String customProjectName, String customPrefix, Map<String, Object> customData, Map<String, Map<String, Object>> customDataMap) {
+        this.selectedTargets = selectedTargets;
+        this.customProjectName = customProjectName;
+        this.customPrefix = customPrefix;
+        this.customData = customData;
+        this.customDataMap = customDataMap;
+    }
+
+    public void perform(Run<?, ?> build, TaskListener listener) {
+
+        // Logging
+        listener.getLogger().println("[InfluxDB Plugin] Collecting data for publication in InfluxDB...");
+
+        // Renderer to use for the metrics
+        MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
+
+        // Points to write
+        List<Point> pointsToWrite = new ArrayList<Point>();
+
+        // Basic metrics
+        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build);
+        addPoints(pointsToWrite, jGen, listener);
+
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData);
+        if (cdGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, cdGen, listener);
+        }
+
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap);
+        if (cdmGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, cdmGen, listener);
+        }
+
+        try {
+            CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build);
+            if (cGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, cGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Cobertura");
+        }
+
+        try {
+            RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build);
+            if (rfGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Robot Framework data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, rfGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Robot Framework");
+        }
+
+        try {
+            JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build);
+            if (jacoGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, jacoGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: JaCoCo");
+        }
+
+        try {
+            PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build);
+            if (perfGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, perfGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Performance");
+        }
+
+        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, listener);
+        if (sonarGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, sonarGen, listener);
+        }
+
+
+        ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build);
+        if (changeLogGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, changeLogGen, listener);
+        }
+
+        try {
+            PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build);
+            if (perfPublisherGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, perfPublisherGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Performance Publisher");
+        }
+
+        // Writes into each selected target
+        for (Target selectedTarget : selectedTargets) {
+            // prepare a meaningful logmessage
+            String logMessage = "[InfluxDB Plugin] Publishing data to: " + selectedTargets;
+            // write to jenkins logger
+            logger.log(Level.INFO, logMessage);
+            // write to jenkins console
+            listener.getLogger().println(logMessage);
+            // connect to InfluxDB
+            InfluxDB influxDB = Strings.isNullOrEmpty(selectedTarget.getUsername()) ?
+                    InfluxDBFactory.connect(selectedTarget.getUrl()) :
+                    InfluxDBFactory.connect(selectedTarget.getUrl(), selectedTarget.getUsername(), selectedTarget.getPassword());
+            // Sending points to the target
+            writeToInflux(selectedTarget, influxDB, pointsToWrite);
+        }
+
+        // We're done
+        listener.getLogger().println("[InfluxDB Plugin] Completed.");
+    }
+
+    private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {
+        try {
+            pointsToWrite.addAll(Arrays.asList(generator.generate()));
+        } catch (Exception e) {
+            listener.getLogger().println("[InfluxDB Plugin] Failed to collect data. Ignoring Exception:" + e);
+        }
+    }
+
+    private void writeToInflux(Target target, InfluxDB influxDB, List<Point> pointsToWrite) {
+        /*
+         * build batchpoints for a single write.
+         */
+        try {
+            BatchPoints batchPoints = BatchPoints
+                    .database(target.getDatabase())
+                    .points(pointsToWrite.toArray(new Point[0]))
+                    .retentionPolicy(target.getRetentionPolicy())
+                    .consistency(ConsistencyLevel.ANY)
+                    .build();
+            influxDB.write(batchPoints);
+        } catch (Exception e) {
+            if (target.isExposeExceptions()) {
+                throw new InfluxReportException(e);
+            } else {
+                //Exceptions not exposed by configuration. Just log and ignore.
+                logger.log(Level.WARNING, "Could not report to InfluxDB. Ignoring Exception.", e);
+            }
+        }
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -1,12 +1,9 @@
 package jenkinsci.plugins.influxdb;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
@@ -14,31 +11,16 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import jenkins.tasks.SimpleBuildStep;
-import jenkinsci.plugins.influxdb.generators.*;
 import jenkinsci.plugins.influxdb.models.Target;
-import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
-import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
-import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDB.ConsistencyLevel;
-import org.influxdb.InfluxDBFactory;
-import org.influxdb.dto.BatchPoints;
-import org.influxdb.dto.Point;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
-
-    /** The logger. **/
-    private static final Logger logger = Logger.getLogger(InfluxDbPublisher.class.getName());
+public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
 
     @Extension(optional = true)
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
@@ -62,11 +44,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      * custom data, especially in pipelines, where additional information is calculated
      * or retrieved by Groovy functions which should be sent to InfluxDB
      * This can easily be done by calling
-     *
-     *   def myDataMap = [:]
-     *   myDataMap['myKey'] = 'myValue'
-     *   step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData: myDataMap])
-     *
+     * <p>
+     * def myDataMap = [:]
+     * myDataMap['myKey'] = 'myValue'
+     * step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData: myDataMap])
+     * <p>
      * inside a pipeline script
      */
     private Map<String, Object> customData;
@@ -74,23 +56,22 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     /**
      * custom data maps, especially in pipelines, where additional information is calculated
      * or retrieved by Groovy functions which should be sent to InfluxDB.
-     *
+     * <p>
      * This goes beyond customData since it allows to define multiple customData measurements
      * where the name of the measurement is defined as the key of the customDataMap.
-     *
+     * <p>
      * Example for a pipeline script:
-     *
-     *   def myDataMap1 = [:]
-     *   def myDataMap2 = [:]
-     *   def myCustomDataMap = [:]
-     *   myDataMap1["myMap1Key1"] = 11 //first value of first map
-     *   myDataMap1["myMap1Key2"] = 12 //second value of first map
-     *   myDataMap2["myMap2Key1"] = 21 //first value of second map
-     *   myDataMap2["myMap2Key2"] = 22 //second value of second map
-     *   myCustomDataMap["series1"] = myDataMap1
-     *   myCustomDataMap["series2"] = myDataMap2
-     *   step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customDataMap: myCustomDataMap])
-     *
+     * <p>
+     * def myDataMap1 = [:]
+     * def myDataMap2 = [:]
+     * def myCustomDataMap = [:]
+     * myDataMap1["myMap1Key1"] = 11 //first value of first map
+     * myDataMap1["myMap1Key2"] = 12 //second value of first map
+     * myDataMap2["myMap2Key1"] = 21 //first value of second map
+     * myDataMap2["myMap2Key2"] = 22 //second value of second map
+     * myCustomDataMap["series1"] = myDataMap1
+     * myCustomDataMap["series2"] = myDataMap2
+     * step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customDataMap: myCustomDataMap])
      */
     private Map<String, Map<String, Object>> customDataMap;
 
@@ -126,7 +107,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     @DataBoundSetter
     public void setCustomProjectName(String customProjectName) {
         this.customProjectName = customProjectName;
-    }    
+    }
 
     public String getCustomPrefix() {
         return customPrefix;
@@ -190,139 +171,25 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @Override
-    public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
+    public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
 
-        MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
-
-        // get the target from the job's config
+        // Gets the target from the job's config
         Target target = getTarget();
-        if (target==null) {
+        if (target == null) {
             throw new RuntimeException("Target was null!");
         }
 
-        // prepare a meaningful logmessage
-        String logMessage = "[InfluxDB Plugin] Publishing data to: " + target.toString();
+        // Preparing the service
+        InfluxDbPublicationService publicationService = new InfluxDbPublicationService(
+                Collections.singletonList(target),
+                customProjectName,
+                customPrefix,
+                customData,
+                customDataMap
+        );
 
-        // write to jenkins logger
-        logger.log(Level.INFO, logMessage);
-        // write to jenkins console
-        listener.getLogger().println(logMessage);
-
-        // connect to InfluxDB
-        InfluxDB influxDB = Strings.isNullOrEmpty(target.getUsername()) ? InfluxDBFactory.connect(target.getUrl()) : InfluxDBFactory.connect(target.getUrl(), target.getUsername(), target.getPassword());
-        List<Point> pointsToWrite = new ArrayList<Point>();
-
-        // finally write to InfluxDB
-        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build);
-        addPoints(pointsToWrite, jGen, listener);
-
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData);
-        if (cdGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, cdGen, listener);
-        }
-
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap);
-        if (cdmGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, cdmGen, listener);
-        }
-
-        try {
-            CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build);
-            if (cGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
-                addPoints(pointsToWrite, cGen, listener);
-            }
-        } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Cobertura");
-        }
-
-        try {
-            RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build);
-            if (rfGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Robot Framework data found. Writing to InfluxDB...");
-                addPoints(pointsToWrite, rfGen, listener);
-            }
-        } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Robot Framework");
-        }
-
-        try {
-            JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build);
-            if (jacoGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
-                addPoints(pointsToWrite, jacoGen, listener);
-            }
-        } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: JaCoCo");
-        }
-
-        try {
-            PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build);
-            if (perfGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
-                addPoints(pointsToWrite, perfGen, listener);
-            }
-        } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Performance");
-        }
-
-        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, listener);
-        if (sonarGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, sonarGen, listener);
-        }
-
-
-        ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build);
-        if (changeLogGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
-            addPoints(pointsToWrite, changeLogGen, listener);
-        }
-
-        try {
-            PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build);
-            if (perfPublisherGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
-                addPoints(pointsToWrite, perfPublisherGen, listener);
-            }
-        } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Performance Publisher");
-        }
-
-        writeToInflux(target, influxDB, pointsToWrite);
-        listener.getLogger().println("[InfluxDB Plugin] Completed.");
-    }
-
-    private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {
-        try {
-            pointsToWrite.addAll(Arrays.asList(generator.generate()));
-        } catch (Exception e) {
-            listener.getLogger().println("[InfluxDB Plugin] Failed to collect data. Ignoring Exception:" + e);
-        }
-    }
-
-    private void writeToInflux(Target target, InfluxDB influxDB, List<Point> pointsToWrite) {
-        /**
-         * build batchpoints for a single write.
-         */
-        try {
-            BatchPoints batchPoints = BatchPoints
-                     .database(target.getDatabase())
-                    .points(pointsToWrite.toArray(new Point[0]))
-                    .retentionPolicy(target.getRetentionPolicy())
-                    .consistency(ConsistencyLevel.ANY)
-                    .build();
-            influxDB.write(batchPoints);
-        } catch (Exception e) {
-            if (target.isExposeExceptions()) {
-                throw new InfluxReportException(e);
-            } else {
-                //Exceptions not exposed by configuration. Just log and ignore.
-                logger.log(Level.WARNING, "Could not report to InfluxDB. Ignoring Exception.", e);
-            }
-        }
+        // Publishes the metrics
+        publicationService.perform(build, listener);
     }
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
@@ -1,0 +1,78 @@
+package jenkinsci.plugins.influxdb.global;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import jenkins.model.Jenkins;
+import jenkinsci.plugins.influxdb.InfluxDbPublicationService;
+import jenkinsci.plugins.influxdb.InfluxDbPublisher;
+import jenkinsci.plugins.influxdb.models.Target;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Listens to call builds being completed, and publishes their metrics
+ * in InfluxDB.
+ */
+@Extension
+public class GlobalRunListener extends RunListener<Run<?, ?>> {
+
+    @Override
+    public void onCompleted(Run<?, ?> build, @Nonnull TaskListener listener) {
+        // Gets the full path of the build's project
+        String path = build.getParent().getRelativeNameFrom(Jenkins.getInstance());
+        // Gets the list of targets from the configuration
+        Target[] targets = InfluxDbPublisher.DESCRIPTOR.getTargets();
+        if (targets != null) {
+            // Selects the targets eligible as global listeners and which match the build path
+            List<Target> selectedTargets = new ArrayList<>();
+            for (Target target : targets) {
+                // Checks if the target matches the path to the project
+                // Skip build if it already publishes information on this target
+                if (isTargetMatchingPath(target, path) && !isPublicationInBuild(target, build)) {
+                    selectedTargets.add(target);
+                }
+            }
+            // If some targets are selected
+            if (!selectedTargets.isEmpty()) {
+                // Creates the publication service
+                InfluxDbPublicationService publicationService = new InfluxDbPublicationService(
+                        selectedTargets,
+                        null,
+                        null,
+                        null,
+                        null
+                );
+                // Publication
+                publicationService.perform(build, listener);
+            }
+        }
+    }
+
+    private boolean isPublicationInBuild(Target target, Run<?, ?> build) {
+        Job<?, ?> parent = build.getParent();
+        if (parent instanceof AbstractProject) {
+            InfluxDbPublisher publisher = (InfluxDbPublisher) ((AbstractProject) parent).getPublishersList().get(InfluxDbPublisher.class);
+            String buildTarget = publisher.getSelectedTarget();
+            return buildTarget != null && StringUtils.equals(buildTarget, target.getDescription());
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isTargetMatchingPath(@Nonnull Target target, @Nonnull String path) {
+        if (target.isGlobalListener()) {
+            String pattern = target.getGlobalListenerFilter();
+            return StringUtils.isBlank(pattern) || Pattern.matches(pattern, path);
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
@@ -60,8 +60,12 @@ public class GlobalRunListener extends RunListener<Run<?, ?>> {
         Job<?, ?> parent = build.getParent();
         if (parent instanceof AbstractProject) {
             InfluxDbPublisher publisher = (InfluxDbPublisher) ((AbstractProject) parent).getPublishersList().get(InfluxDbPublisher.class);
-            String buildTarget = publisher.getSelectedTarget();
-            return buildTarget != null && StringUtils.equals(buildTarget, target.getDescription());
+            if (publisher != null) {
+                String buildTarget = publisher.getSelectedTarget();
+                return buildTarget != null && StringUtils.equals(buildTarget, target.getDescription());
+            } else {
+                return false;
+            }
         } else {
             return false;
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -9,6 +9,8 @@ public class Target {
     String database;
     String retentionPolicy;
     boolean exposeExceptions;
+    boolean globalListener;
+    String globalListenerFilter;
 
     public Target(){
         //nop
@@ -70,9 +72,32 @@ public class Target {
         this.exposeExceptions = exposeExceptions;
     }
 
+    public boolean isGlobalListener() {
+        return globalListener;
+    }
+
+    public void setGlobalListener(boolean globalListener) {
+        this.globalListener = globalListener;
+    }
+
+    public String getGlobalListenerFilter() {
+        return globalListenerFilter;
+    }
+
+    public void setGlobalListenerFilter(String globalListenerFilter) {
+        this.globalListenerFilter = globalListenerFilter;
+    }
+
     @Override
     public String toString() {
-        return "[url=" + this.url + ", description=" + this.description + ", username=" + this.username
-                + ", password=*****, database=" + this.database + "]";
+        return "[" +
+                "description='" + description + '\'' +
+                ", url='" + url + '\'' +
+                ", database='" + database + '\'' +
+                ", retentionPolicy='" + retentionPolicy + '\'' +
+                ", exposeExceptions=" + exposeExceptions +
+                ", globalListener=" + globalListener +
+                ", globalListenerFilter='" + globalListenerFilter + '\'' +
+                ']';
     }
 }

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -39,6 +39,14 @@
                          <f:checkbox name="targetBinding.exposeExceptions" checked="${currentTarget.exposeExceptions}" default="true" />
                       </f:entry>
 
+                      <f:entry title="globalListener" field="globalListener" >
+                         <f:checkbox name="targetBinding.globalListener" checked="${currentTarget.globalListener}" default="false" />
+                      </f:entry>
+
+                      <f:entry title="globalListenerFilter" field="globalListenerFilter" >
+                         <f:textbox name="targetBinding.globalListenerFilter" value="${currentTarget.globalListenerFilter}" default="" />
+                      </f:entry>
+
                       <f:entry title="delete target" >
                         <div align="right">
                           <f:repeatableDeleteButton value="delete target"/>


### PR DESCRIPTION
This PR allows to flag some targets (an InfluxDB database) to listen at all build completions in Jenkins and to send its metrics to the target.

* the target can be flagged to send metrics for all builds (by default: no, like today)
* the target can be associated with a regular expression to match only some project paths (by default: all of them)
* the global metrics to a given target are not sent if the project is already associated with a publication for this target (to avoid sending the same metrics to the same target twice)
* the code of the `InfluxDbPublisher` has been refactored to use the same code than some the global metrics

The rationale for this change is to allow a global setup of the metrics over all the jobs and projects of a Jenkins instance.

Best regards,
Damien.