### PR TITLE
add custom tags property

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -94,6 +94,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Map<String, Object>> customDataMap;
 
+    private Map<String, String> globalTags;
+
     public InfluxDbPublisher() {
     }
 
@@ -154,6 +156,13 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     public Map<String, Map<String, Object>> getCustomDataMap() {
         return customDataMap;
     }
+
+    @DataBoundSetter
+    public void setGlobalTags(Map<String, String> globalTags) {
+        this.globalTags = globalTags;
+    }
+
+    public Map<String, String> getGlobalTags() { return globalTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();
@@ -223,7 +232,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             addPoints(pointsToWrite, cdGen, listener);
         }
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, globalTags);
         if (cdmGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -158,11 +158,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
-    public void setcustomDataMapTags(Map<String, String> customDataMapTags) {
+    public void setCustomDataMapTags(Map<String, String> customDataMapTags) {
         this.customDataMapTags = customDataMapTags;
     }
 
-    public Map<String, String> getcustomDataMapTags() { return customDataMapTags; }
+    public Map<String, String> getCustomDataMapTags() { return customDataMapTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -99,17 +99,19 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      *
      * Example for a pipeline script:
      *
+     * def myCustomDataMapTags = [:]
      * def myCustomTags = [:]
      * myCustomTags["buildResult"] = currentBuild.result
      * myCustomTags["NODE_LABELS"] = env.NODE_LABELS
+     * myCustomDataMapTags["series1"] = myCustomTags
      * step([$class: 'InfluxDbPublisher',
      *       target: myTarget,
      *       customPrefix: 'myPrefix',
      *       customDataMap: myCustomDataMap,
-     *       customDataMapTags: myCustomTags])
+     *       customDataMapTags: myCustomDataMapTags])
      */
 
-    private Map<String, String> customDataMapTags;
+    private Map<String, Map<String, String>> customDataMapTags;
 
     public InfluxDbPublisher() {
     }
@@ -173,11 +175,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
-    public void setCustomDataMapTags(Map<String, String> customDataMapTags) {
+    public void setCustomDataMapTags(Map<String, Map<String, String>> customDataMapTags) {
         this.customDataMapTags = customDataMapTags;
     }
 
-    public Map<String, String> getCustomDataMapTags() { return customDataMapTags; }
+    public Map<String, Map<String, String>> getCustomDataMapTags() { return customDataMapTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -71,6 +71,20 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Object> customData;
 
+
+    /**
+     * custom data tags, especially in pipelines, where additional information is calculated
+     * or retrieved by Groovy functions which should be sent to InfluxDB
+     * This can easily be done by calling
+     *
+     *   def myDataMapTags = [:]
+     *   myDataMapTags['myKey'] = 'myValue'
+     *   step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData: myDataMap, customDataTags: myDataMapTags])
+     *
+     * inside a pipeline script
+     */
+    private Map<String, String> customDataTags;
+
     /**
      * custom data maps, especially in pipelines, where additional information is calculated
      * or retrieved by Groovy functions which should be sent to InfluxDB.
@@ -166,6 +180,15 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
+    public void setCustomDataTags(Map<String, String> customDataTags) {
+        this.customDataTags = customDataTags;
+    }
+
+    public Map<String, String> getCustomDataTags() {
+        return customDataTags;
+    }
+
+    @DataBoundSetter
     public void setCustomDataMap(Map<String, Map<String, Object>> customDataMap) {
         this.customDataMap = customDataMap;
     }
@@ -243,7 +266,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build);
         addPoints(pointsToWrite, jGen, listener);
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData, customDataTags);
         if (cdGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -94,7 +94,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Map<String, Object>> customDataMap;
 
-    private Map<String, String> globalTags;
+    private Map<String, String> customDataMapTags;
 
     public InfluxDbPublisher() {
     }
@@ -158,11 +158,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
-    public void setGlobalTags(Map<String, String> globalTags) {
-        this.globalTags = globalTags;
+    public void setcustomDataMapTags(Map<String, String> customDataMapTags) {
+        this.customDataMapTags = customDataMapTags;
     }
 
-    public Map<String, String> getGlobalTags() { return globalTags; }
+    public Map<String, String> getcustomDataMapTags() { return customDataMapTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();
@@ -232,7 +232,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             addPoints(pointsToWrite, cdGen, listener);
         }
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, globalTags);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, customDataMapTags);
         if (cdmGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -94,6 +94,21 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Map<String, Object>> customDataMap;
 
+    /**
+     * custom tags that are sent to all measurements defined in customDataMaps.
+     *
+     * Example for a pipeline script:
+     *
+     * def myCustomTags = [:]
+     * myCustomTags["buildResult"] = currentBuild.result
+     * myCustomTags["NODE_LABELS"] = env.NODE_LABELS
+     * step([$class: 'InfluxDbPublisher',
+     *       target: myTarget,
+     *       customPrefix: 'myPrefix',
+     *       customDataMap: myCustomDataMap,
+     *       customDataMapTags: myCustomTags])
+     */
+
     private Map<String, String> customDataMapTags;
 
     public InfluxDbPublisher() {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -12,13 +12,17 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
-    Map<String, Map<String, Object>> customDataMap;
+    private final Map<String, Map<String, Object>> customDataMap;
+    private final Map<String, String> globalTags;
 
-    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map customDataMap) {
+    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
+                                       Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
+                                       Map<String, String> globalTags) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customDataMap = customDataMap;
+        this.globalTags = globalTags;
     }
 
     public boolean hasReport() {
@@ -31,6 +35,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
         for (String key : customKeys) {
             Point point = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key))
+                    .tag(globalTags)
                     .build();
             customPoints.add(point);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -13,7 +13,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
     private final Run<?, ?> build;
     private final String customPrefix;
     Map<String, Map<String, Object>> customDataMap;
-    private final Map<String, String> customDataMapTags;
+    Map<String, String> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
                                        Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
@@ -32,11 +32,19 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
     public Point[] generate() {
         List<Point> customPoints = new ArrayList<Point>();
         Set<String> customKeys = customDataMap.keySet();
+
         for (String key : customKeys) {
-            Point point = buildPoint(measurementName(key), customPrefix, build)
-                    .fields(customDataMap.get(key))
-                    .tag(customDataMapTags)
-                    .build();
+            Point.Builder pointBuilder;
+
+            pointBuilder = buildPoint(measurementName(key), customPrefix, build)
+                    .fields(customDataMap.get(key));
+
+            if (customDataMapTags != null && customDataMapTags.size() > 0) {
+                pointBuilder = pointBuilder.tag(customDataMapTags);
+            }
+
+            Point point = pointBuilder.build();
+
             customPoints.add(point);
         }
         return customPoints.toArray(new Point[customPoints.size()]);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -12,7 +12,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
-    private final Map<String, Map<String, Object>> customDataMap;
+    Map<String, Map<String, Object>> customDataMap;
     private final Map<String, String> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -13,16 +13,16 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
     private final Run<?, ?> build;
     private final String customPrefix;
     private final Map<String, Map<String, Object>> customDataMap;
-    private final Map<String, String> globalTags;
+    private final Map<String, String> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
                                        Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
-                                       Map<String, String> globalTags) {
+                                       Map<String, String> customDataMapTags) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customDataMap = customDataMap;
-        this.globalTags = globalTags;
+        this.customDataMapTags = customDataMapTags;
     }
 
     public boolean hasReport() {
@@ -35,7 +35,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
         for (String key : customKeys) {
             Point point = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key))
-                    .tag(globalTags)
+                    .tag(customDataMapTags)
                     .build();
             customPoints.add(point);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -13,11 +13,11 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
     private final Run<?, ?> build;
     private final String customPrefix;
     Map<String, Map<String, Object>> customDataMap;
-    Map<String, String> customDataMapTags;
+    Map<String, Map<String, String>> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
                                        Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
-                                       Map<String, String> customDataMapTags) {
+                                       Map<String, Map<String, String>> customDataMapTags) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
@@ -37,8 +37,11 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
             Point.Builder pointBuilder = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key));
 
-            if (customDataMapTags != null && customDataMapTags.size() > 0) {
-                pointBuilder = pointBuilder.tag(customDataMapTags);
+            Map<String, String> customTags = customDataMapTags.get(key);
+            if (customTags != null) {
+                if (customTags.size() > 0){
+                    pointBuilder = pointBuilder.tag(customTags);
+                }
             }
 
             Point point = pointBuilder.build();

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -34,9 +34,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
         Set<String> customKeys = customDataMap.keySet();
 
         for (String key : customKeys) {
-            Point.Builder pointBuilder;
-
-            pointBuilder = buildPoint(measurementName(key), customPrefix, build)
+            Point.Builder pointBuilder = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key));
 
             if (customDataMapTags != null && customDataMapTags.size() > 0) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -13,12 +13,15 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
     private final Run<?, ?> build;
     private final String customPrefix;
     Map<String, Object> customData;
+    Map<String, String> customDataTags;
 
-    public CustomDataPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map customData) {
+    public CustomDataPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
+                                    Run<?, ?> build, Map customData, Map<String, String> customDataTags) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customData = customData;
+        this.customDataTags = customDataTags;
     }
 
     public boolean hasReport() {
@@ -29,10 +32,19 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
         long startTime = build.getTimeInMillis();
         long currTime = System.currentTimeMillis();
         long dt = currTime - startTime;
-        Point point = buildPoint(measurementName("jenkins_custom_data"), customPrefix, build)
+
+        Point.Builder pointBuilder = buildPoint(measurementName("jenkins_custom_data"), customPrefix, build)
                 .addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
-                .fields(customData)
-                .build();
+                .fields(customData);
+
+        if (customDataTags != null) {
+            if (customDataTags.size() > 0) {
+                pointBuilder = pointBuilder.tag(customDataTags);
+            }
+        }
+
+        Point point = pointBuilder.build();
+
         return new Point[] {point};
     }
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -67,7 +67,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             .addField(BUILD_IS_SUCCESSFUL, ordinal < 2 ? true : false)
             .addField(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
             .addField(PROJECT_LAST_SUCCESSFUL, getLastSuccessfulBuild())
-            .addField(PROJECT_LAST_STABLE, getLastStableBuild());
+            .addField(PROJECT_LAST_STABLE, getLastStableBuild())
+            .tag(BUILD_RESULT, result);
 
         if(hasTestResults(build)) {
             point.addField(TESTS_FAILED, build.getAction(AbstractTestResultAction.class).getFailCount());

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -38,16 +38,21 @@ public class CustomDataMapPointGeneratorTest {
     @Test
     public void hasReportTest() {
         //check with customDataMap = null
-        CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null);
+        CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+                null, null);
         Assert.assertFalse(cdmGen1.hasReport());
 
         //check with empty customDataMap
-        CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap());
+        CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+                Collections.<String, Map<String, Object>>emptyMap(), Collections.<String, String>emptyMap());
         Assert.assertFalse(cdmGen2.hasReport());
     }
 
     @Test
     public void generateTest() {
+
+        Map<String, String> globalTags = new HashMap<>();
+        globalTags.put("test1Tag", "testValue");
 
         Map<String, Object> customData1 = new HashMap<String, Object>();
         customData1.put("test1", 11);
@@ -66,7 +71,8 @@ public class CustomDataMapPointGeneratorTest {
 
         List<Point> pointsToWrite = new ArrayList<Point>();
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customDataMap);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+                customDataMap, globalTags);
         pointsToWrite.addAll(Arrays.asList(cdmGen.generate()));
 
         String lineProtocol1;
@@ -78,7 +84,8 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite.get(1).lineProtocol();
             lineProtocol2 = pointsToWrite.get(0).lineProtocol();
         }
-        Assert.assertTrue(lineProtocol1.startsWith("series1,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
-        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
+
+        Assert.assertTrue(lineProtocol1.startsWith("series1,prefix=test_prefix,project_name=test_prefix_master,test1Tag=testValue build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
+        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,test1Tag=testValue build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -51,8 +51,8 @@ public class CustomDataMapPointGeneratorTest {
     @Test
     public void generateTest() {
 
-        Map<String, String> globalTags = new HashMap<>();
-        globalTags.put("test1Tag", "testValue");
+        Map<String, String> customDataMapTags = new HashMap<>();
+        customDataMapTags.put("test1Tag", "testValue");
 
         Map<String, Object> customData1 = new HashMap<String, Object>();
         customData1.put("test1", 11);
@@ -72,7 +72,7 @@ public class CustomDataMapPointGeneratorTest {
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
-                customDataMap, globalTags);
+                customDataMap, customDataMapTags);
         pointsToWrite.addAll(Arrays.asList(cdmGen.generate()));
 
         String lineProtocol1;

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -44,15 +44,12 @@ public class CustomDataMapPointGeneratorTest {
 
         //check with empty customDataMap
         CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
-                Collections.<String, Map<String, Object>>emptyMap(), Collections.<String, String>emptyMap());
+                Collections.<String, Map<String, Object>>emptyMap(), Collections.<String, Map<String, String>>emptyMap());
         Assert.assertFalse(cdmGen2.hasReport());
     }
 
     @Test
     public void generateTest() {
-
-        Map<String, String> customDataMapTags = new HashMap<>();
-        customDataMapTags.put("test1Tag", "testValue");
 
         Map<String, Object> customData1 = new HashMap<String, Object>();
         customData1.put("test1", 11);
@@ -67,6 +64,11 @@ public class CustomDataMapPointGeneratorTest {
         Map<String, Map<String, Object>> customDataMap = new HashMap<String, Map<String, Object>>();
         customDataMap.put("series1", customData1);
         customDataMap.put("series2", customData2);
+
+        Map<String, Map<String, String>> customDataMapTags = new HashMap<String, Map<String, String>>();
+        Map<String, String> customTags = new HashMap<String, String>();
+        customTags.put("build_result", "SUCCESS");
+        customDataMapTags.put("series1", customTags);
 
 
         List<Point> pointsToWrite = new ArrayList<Point>();
@@ -85,7 +87,9 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol2 = pointsToWrite.get(0).lineProtocol();
         }
 
-        Assert.assertTrue(lineProtocol1.startsWith("series1,prefix=test_prefix,project_name=test_prefix_master,test1Tag=testValue build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
-        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,test1Tag=testValue build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
+        System.out.println(lineProtocol1);
+        System.out.println(lineProtocol2);
+        Assert.assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
+        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -86,9 +86,7 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite.get(1).lineProtocol();
             lineProtocol2 = pointsToWrite.get(0).lineProtocol();
         }
-
-        System.out.println(lineProtocol1);
-        System.out.println(lineProtocol2);
+        
         Assert.assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
         Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -86,7 +86,7 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite.get(1).lineProtocol();
             lineProtocol2 = pointsToWrite.get(0).lineProtocol();
         }
-        
+
         Assert.assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
         Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -38,11 +38,11 @@ public class CustomDataPointGeneratorTest {
     @Test
     public void hasReportTest() {
         //check with customDataMap = null
-        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null);
+        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null, null);
         Assert.assertFalse(cdGen1.hasReport());
 
         //check with empty customDataMap
-        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap());
+        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap(), null);
         Assert.assertFalse(cdGen2.hasReport());
     }
 
@@ -53,13 +53,17 @@ public class CustomDataPointGeneratorTest {
         customData.put("test1", 11);
         customData.put("test2", 22);
 
+        Map<String, String> customDataTags = new HashMap<String, String>();
+        customDataTags.put("tag1", "myTag");
+
+
         List<Point> pointsToWrite = new ArrayList<Point>();
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData, customDataTags);
         pointsToWrite.addAll(Arrays.asList(cdGen.generate()));
 
         String lineProtocol = pointsToWrite.get(0).lineProtocol();
-        Assert.assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master build_number=11i,build_time="));
+        Assert.assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,tag1=myTag build_number=11i,build_time="));
         Assert.assertTrue(lineProtocol.indexOf("project_name=\"test_prefix_master\",test1=11i,test2=22i")>0);
     }
 }


### PR DESCRIPTION
This PR adds a property to the publisher that allows for custom tags to be added with any measurement sent with CustomDataMap. This will allow for more flexibility while querying with GROUP BY.