### PR TITLE
fix JENKINS-50962

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -17,7 +17,7 @@ import net.sf.json.JSONObject;
 public final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject {
  
     public static final String DISPLAY_NAME = "Publish build data to InfluxDb target";
-    private final CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
+    private CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
  
     public DescriptorImpl() {
         super(InfluxDbPublisher.class);

--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -33,7 +33,11 @@ public final class DescriptorImpl extends BuildStepDescriptor<Publisher> impleme
         }
         return targets.toArray(new Target[size]);
     }
- 
+
+    public void setTargets(CopyOnWriteList newTargets) {
+        targets = newTargets;
+    }
+
     @Override
     public String getDisplayName() {
         return DISPLAY_NAME;


### PR DESCRIPTION
This give the ability to set influxdb from groovy.

you can test in [Jenkins Console](https://wiki.jenkins.io/display/JENKINS/Jenkins+Script+Console) with 

```groovy
import jenkinsci.plugins.influxdb.models.Target
import hudson.util.CopyOnWriteList;

def influxdb = Jenkins.instance.getDescriptorByType(jenkinsci.plugins.influxdb.DescriptorImpl)

def target = new Target()
target.description = 'mydb'
target.url = 'http://10.10.10.10:8086'
target.username = 'admin'
target.password = 'admin'
target.database = 'db0'
CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
targets.add(target)
influxdb.targets = targets

influxdb.save()
```