### PR TITLE
add optional and resolvable jenkins-env-parameter as field and/or tag to JenkinsBasePointGenerator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.15</version>
+    <version>1.16-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.15-SNAPSHOT</version>
+    <version>1.15</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.15</tag>
     </scm>
 
     <properties>

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -1,10 +1,23 @@
 package jenkinsci.plugins.influxdb.generators;
 
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import hudson.EnvVars;
 import hudson.model.Executor;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.influxdb.dto.Point;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Properties;
 
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
@@ -33,11 +46,17 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
+    private final TaskListener listener;
+    private final String jenkinsEnvParameterField;
+    private final String jenkinsEnvParameterTag;
 
-    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build) {
+    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix, Run<?, ?> build, TaskListener listener, String jenkinsEnvParameterField, String jenkinsEnvParameterTag) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
+        this.listener = listener;
+        this.jenkinsEnvParameterField = jenkinsEnvParameterField;
+        this.jenkinsEnvParameterTag = jenkinsEnvParameterTag;
     }
 
     public boolean hasReport() {
@@ -80,6 +99,18 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             point.addField(TESTS_TOTAL, build.getAction(AbstractTestResultAction.class).getTotalCount());
         }
 
+        if (StringUtils.isNotBlank(jenkinsEnvParameterField)) {
+            Properties fieldProperties = parsePropertiesString(jenkinsEnvParameterField);
+            Map fieldMap = resolveEnvParameterAndTransformToMap(fieldProperties);
+            point.fields(fieldMap);
+        }
+
+        if (StringUtils.isNotBlank(jenkinsEnvParameterTag)) {
+            Properties tagProperties = parsePropertiesString(jenkinsEnvParameterTag);
+            Map tagMap = resolveEnvParameterAndTransformToMap(tagProperties);
+            point.tag(tagMap);
+        }
+
         return new Point[] {point.build()};
     }
 
@@ -108,5 +139,44 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             return build.getParent().getLastStableBuild().getNumber();
         else
             return 0;
+    }
+
+    private Properties parsePropertiesString(final String propertiesString) {
+        final Properties properties = new Properties();
+        try {
+            StringReader reader = new StringReader(propertiesString);
+            properties.load(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return properties;
+    }
+
+    private Map<String, Object> resolveEnvParameterAndTransformToMap(final Properties properties) {
+        ImmutableMap<String, String> propertiesMap = Maps.fromProperties(properties);
+        return Maps.transformValues(propertiesMap, new Function<String, Object>() {
+            @Nullable
+            @Override
+            public Object apply(@Nullable String value) {
+                if (containsEnvParameter(value)) {
+                    return resolveEnvParameter(value);
+                }
+                return value;
+            }
+        });
+    }
+
+    private boolean containsEnvParameter(final String value) {
+        return StringUtils.length(value) > 3 && StringUtils.contains(value, "${");
+    }
+
+    private String resolveEnvParameter(final String stringValue) {
+        try {
+            EnvVars envVars = build.getEnvironment(listener);
+            return StrSubstitutor.replace(stringValue, envVars);
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+        return stringValue;
     }
 }

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
@@ -18,6 +18,12 @@
           <f:entry title="custom-project-name" field="customProjectName" >
               <f:textbox name="publisherBinding.customProjectName" value="${publisherBinding.customProjectName}"/>
           </f:entry>
+           <f:entry title="jenkins-env-parameter FieldSet" field="jenkinsEnvParameterField">
+               <f:textarea name="publisherBinding.jenkinsEnvParameterField" value="${publisherBinding.jenkinsEnvParameterField}"/>
+           </f:entry>
+           <f:entry title="jenkins-env-parameter TagSet" field="jenkinsEnvParameterTag">
+               <f:textarea name="publisherBinding.jenkinsEnvParameterTag" value="${publisherBinding.jenkinsEnvParameterTag}"/>
+           </f:entry>
        </f:advanced>
   </f:section>
 

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jenkinsEnvParameterField.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jenkinsEnvParameterField.html
@@ -1,0 +1,8 @@
+Custom FieldSets that will be added to the default measurement 'jenkins_data', configured as key-value-pairs (one per line, in Java-Properties file format).
+<br />
+Current build parameters and/or environment variables can be used in form ${PARAM}
+<ul>
+    <li>KEY=${PARAM}</li>
+    <li>KEY=PREFIX_${PARAM}_SUFFIX</li>
+    <li>KEY=VALUE</li>
+</ul>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jenkinsEnvParameterTag.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jenkinsEnvParameterTag.html
@@ -1,0 +1,8 @@
+Custom TagSets that will be added to the default measurement 'jenkins_data', configured as key-value-pairs (one per line, in Java-Properties file format).
+<br />
+Current build parameters and/or environment variables can be used in form ${PARAM}
+<ul>
+    <li>KEY=${PARAM}</li>
+    <li>KEY=PREFIX_${PARAM}_SUFFIX</li>
+    <li>KEY=VALUE</li>
+</ul>

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -1,15 +1,23 @@
 package jenkinsci.plugins.influxdb.generators;
 
+import hudson.EnvVars;
 import hudson.model.*;
 import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.apache.commons.lang.StringUtils;
+import org.hamcrest.Matchers;
 import org.influxdb.dto.Point;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Damien Coraboeuf <damien.coraboeuf@gmail.com>
@@ -19,32 +27,55 @@ public class JenkinsBasePointGeneratorTest {
     public static final int BUILD_NUMBER = 11;
     public static final String CUSTOM_PREFIX = "test_prefix";
 
+    public static final String JENKINS_ENV_PARAMETER_FIELD =
+                    "testKey1=testValueField\n" +
+                    "testKey2=${incompleteEnvValueField\n" +
+                    "testEnvKeyField1=${testEnvValueField}\n" +
+                    "testEnvKeyField2=PREFIX_${testEnvValueField}_${testEnvValueField}_SUFFIX";
+    private static final String JENKINS_ENV_VALUE_FIELD = "testEnvValueField";
+    private static final String JENKINS_ENV_RESOLVED_VALUE_FIELD = "resolvedEnvValueField";
+
+    public static final String JENKINS_ENV_PARAMETER_TAG =
+                    "testKey1=testValueTag\n" +
+                    "testKey2=${incompleteEnvValueTag\n" +
+                    "testEnvKeyTag1=${testEnvValueTag}\n" +
+                    "testEnvKeyTag2=PREFIX_${testEnvValueTag}_${testEnvValueTag}_SUFFIX";
+    private static final String JENKINS_ENV_VALUE_TAG = "testEnvValueTag";
+    private static final String JENKINS_ENV_RESOLVED_VALUE_TAG = "resolvedEnvValueTag";
+
     private Run<?, ?> build;
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
     private Executor executor;
+    private TaskListener listener;
+    private EnvVars mockedEnvVars;
 
     @Before
-    public void before() {
+    public void before() throws IOException, InterruptedException {
         build = Mockito.mock(Run.class);
         Job job = Mockito.mock(Job.class);
         executor = Mockito.mock(Executor.class);
+        listener = Mockito.mock(TaskListener.class);
+        mockedEnvVars = Mockito.mock(EnvVars.class);
         Computer computer = Mockito.mock(Computer.class);
         measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
 
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getBuildStatusSummary()).thenReturn(new Run.Summary(false, "OK"));
         Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(build.getEnvironment(listener)).thenReturn(mockedEnvVars);
         Mockito.when(executor.getOwner()).thenReturn(computer);
         Mockito.when(computer.getName()).thenReturn("slave-1");
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
         Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
         Mockito.when(job.getBuildHealth()).thenReturn(new HealthReport());
+        Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_FIELD)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_FIELD);
+        Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_TAG)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_TAG);
     }
 
     @Test
     public void agent_present() {
         Mockito.when(build.getExecutor()).thenReturn(executor);
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"slave-1\""));
@@ -54,10 +85,70 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void agent_not_present() {
         Mockito.when(build.getExecutor()).thenReturn(null);
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"\""));
         Assert.assertTrue(points[0].lineProtocol().contains("project_path=\"folder/master\""));
+    }
+
+    @Test
+    public void valid_jenkins_env_parameter_for_fields_present() {
+        JenkinsBasePointGenerator jenkinsBasePointGenerator =
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, StringUtils.EMPTY);
+        Point[] generatedPoints = jenkinsBasePointGenerator.generate();
+        String lineProtocol = generatedPoints[0].lineProtocol();
+
+        assertThat(lineProtocol, containsString("testKey1=\"testValueField\""));
+        assertThat(lineProtocol, containsString("testKey2=\"${incompleteEnvValueField\""));
+        assertThat(lineProtocol, containsString("testEnvKeyField1=\"" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "\""));
+        assertThat(lineProtocol, containsString("testEnvKeyField2=\"PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "_" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "_SUFFIX\""));
+
+        assertThat(lineProtocol, not(containsString("testValueTag")));
+        assertThat(lineProtocol, not(containsString("${incompleteEnvValueTag")));
+        assertThat(lineProtocol, not(containsString("testEnvKeyTag1")));
+        assertThat(lineProtocol, not(containsString(JENKINS_ENV_RESOLVED_VALUE_TAG)));
+        assertThat(lineProtocol, not(containsString("testEnvKeyTag2")));
+        assertThat(lineProtocol, not(containsString("PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_TAG + "_SUFFIX")));
+    }
+
+    @Test
+    public void valid_jenkins_env_parameter_for_tags_present() {
+        JenkinsBasePointGenerator jenkinsBasePointGenerator =
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, JENKINS_ENV_PARAMETER_TAG);
+        Point[] generatedPoints = jenkinsBasePointGenerator.generate();
+        String lineProtocol = generatedPoints[0].lineProtocol();
+
+        assertThat(lineProtocol, containsString("testKey1=testValueTag"));
+        assertThat(lineProtocol, containsString("testKey2=${incompleteEnvValueTag"));
+        assertThat(lineProtocol, containsString("testEnvKeyTag1=" + JENKINS_ENV_RESOLVED_VALUE_TAG));
+        assertThat(lineProtocol, containsString("testEnvKeyTag2=PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_TAG + "_" + JENKINS_ENV_RESOLVED_VALUE_TAG +"_SUFFIX"));
+
+        assertThat(lineProtocol, not(containsString("testValueField")));
+        assertThat(lineProtocol, not(containsString("${incompleteEnvValueField")));
+        assertThat(lineProtocol, not(containsString("testEnvKeyField1")));
+        assertThat(lineProtocol, not(containsString(JENKINS_ENV_RESOLVED_VALUE_FIELD)));
+        assertThat(lineProtocol, not(containsString("testEnvKeyField2")));
+        assertThat(lineProtocol, not(containsString("PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "_SUFFIX")));
+    }
+
+    @Test
+    public void valid_jenkins_env_parameter_for_fields_and_tags_present() {
+        JenkinsBasePointGenerator jenkinsBasePointGenerator =
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, JENKINS_ENV_PARAMETER_TAG);
+        Point[] generatedPoints = jenkinsBasePointGenerator.generate();
+        String lineProtocol = generatedPoints[0].lineProtocol();
+
+        assertThat(lineProtocol, containsString("testKey1=\"testValueField\""));
+        assertThat(lineProtocol, containsString("testKey2=\"${incompleteEnvValueField\""));
+
+        assertThat(lineProtocol, containsString("testEnvKeyField1=\"" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "\""));
+        assertThat(lineProtocol, containsString("testEnvKeyField2=\"PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "_" + JENKINS_ENV_RESOLVED_VALUE_FIELD + "_SUFFIX\""));
+
+        assertThat(lineProtocol, containsString("testKey1=testValueTag"));
+        assertThat(lineProtocol, containsString("testKey2=${incompleteEnvValueTag"));
+
+        assertThat(lineProtocol, containsString("testEnvKeyTag1=" + JENKINS_ENV_RESOLVED_VALUE_TAG));
+        assertThat(lineProtocol, containsString("testEnvKeyTag2=PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_TAG + "_" + JENKINS_ENV_RESOLVED_VALUE_TAG + "_SUFFIX"));
     }
 }


### PR DESCRIPTION
This pull request allows you to complement the actual jenkins-data (measurement 'jenkins_data') with configurable tag- and/or fieldSets, whose values are resolved from build parameter or env-variables.

This may be interesting, if you do not work with the pipeline-plugin.
It is possible to configure key-value -pairs (java-properties file format) with environment- or buildjob-parameters.
I've added two optional textareas in the 'Advanced Settings' section of the publisher configuration, each for TagSets and FieldSets.
