### PR TITLE
JENKINS-50962 - set influxdb servers detail from groovy scripts

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -17,7 +17,7 @@ import net.sf.json.JSONObject;
 public final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject {
  
     public static final String DISPLAY_NAME = "Publish build data to InfluxDb target";
-    private final CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
+    private CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
  
     public DescriptorImpl() {
         super(InfluxDbPublisher.class);
@@ -33,7 +33,11 @@ public final class DescriptorImpl extends BuildStepDescriptor<Publisher> impleme
         }
         return targets.toArray(new Target[size]);
     }
- 
+
+    public void setTargets(CopyOnWriteList newTargets) {
+        targets = newTargets;
+    }
+
     @Override
     public String getDisplayName() {
         return DISPLAY_NAME;


### PR DESCRIPTION
This give the ability to set influxdb servers detail from groovy scripts, (cf JENKINS-50962)

this PR is a follow of https://github.com/jenkinsci/influxdb-plugin/pull/31
you can test it using the [Jenkins Console](https://wiki.jenkins.io/display/JENKINS/Jenkins+Script+Console).

We could already list the servers with groovy

```groovy
import jenkinsci.plugins.influxdb.models.Target

def influxdb = Jenkins.instance.getDescriptorByType(jenkinsci.plugins.influxdb.DescriptorImpl)

println "list of InfluxDB Targets:"
println "========================="
influxdb.targets.each { target ->
  println """
description = '${target.description}'"
url = '${target.url}'
username = '${target.username}'
password = '${target.password}'
database = '${target.database}'
=========================
"""
}
```

Which will print something like

```
list of InfluxDB Targets:
=========================
description = 'myserver1'"
url = 'http://10.37.24.14:8086/'
username = 'telegraf'
password = 'myPassword'
database = 'db0'
=========================
description = 'myserver1'"
url = 'http://10.37.24.15:8086/'
username = 'telegraf'
password = 'myPassword'
database = 'db0'
=========================
```

We can now, with this PR, override these servers with new ones

```groovy
import jenkinsci.plugins.influxdb.models.Target
import hudson.util.CopyOnWriteList

def influxdb = Jenkins.instance.getDescriptorByType(jenkinsci.plugins.influxdb.DescriptorImpl)

def target = new Target()
target.description = 'mydb'
target.url = 'http://10.10.10.10:8086'
target.username = 'admin'
target.password = 'admin'
target.database = 'db0'
CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>()
targets.add(target)
influxdb.targets = targets

influxdb.save()
```