### PR TITLE
set real build-start/sheduled-time as PointTime in JenkinsBasePointGenerator

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -7,6 +7,8 @@ import jenkins.metrics.impl.TimeInQueueAction;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 
+import java.util.concurrent.TimeUnit;
+
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     public static final String BUILD_TIME = "build_time";
@@ -44,6 +46,12 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     public boolean hasReport() {
         return true;
+    }
+
+    @Override
+    public Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build) {
+        return super.buildPoint(name, customPrefix, build)
+                .time(build.getTimeInMillis(), TimeUnit.MILLISECONDS);
     }
 
     public Point[] generate() {


### PR DESCRIPTION
Overwrite buildPoint()-Method in JenkinsBasePointGenerator to set real build-start/sheduled-time as PointTime instead of time when Point is created (when BuildJob is done or in PostProcess).
