### PR TITLE
add additional timestamps as fields in JenkinsPointGenerator

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -3,7 +3,6 @@ package jenkinsci.plugins.influxdb.generators;
 import hudson.model.Executor;
 import hudson.model.Run;
 import hudson.tasks.test.AbstractTestResultAction;
-import jenkins.metrics.impl.TimeInQueueAction;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 
@@ -12,6 +11,9 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String BUILD_TIME = "build_time";
     public static final String BUILD_STATUS_MESSAGE = "build_status_message";
     public static final String TIME_IN_QUEUE = "time_in_queue";
+    public static final String BUILD_SCHEDULED_TIME = "build_scheduled_time";
+    public static final String BUILD_EXEC_TIME = "build_exec_time";
+    public static final String BUILD_MEASURED_TIME = "build_measured_time";
 
     /* BUILD_RESULT BUILD_RESULT_ORDINAL BUILD_IS_SUCCESSFUL - explanation
      * SUCCESS   0 true  - The build had no errors.
@@ -66,6 +68,9 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         Point.Builder point = buildPoint(measurementName("jenkins_data"), customPrefix, build);
 
         point.addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
+            .addField(BUILD_SCHEDULED_TIME, build.getTimeInMillis())
+            .addField(BUILD_EXEC_TIME, build.getStartTimeInMillis())
+            .addField(BUILD_MEASURED_TIME, currTime)
             .addField(BUILD_STATUS_MESSAGE, build.getBuildStatusSummary().message)
             .addField(BUILD_RESULT, result)
             .addField(BUILD_RESULT_ORDINAL, ordinal)

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -4,11 +4,12 @@ import hudson.model.*;
 import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.apache.commons.lang.StringUtils;
+import org.hamcrest.Matchers;
 import org.influxdb.dto.Point;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 /**
@@ -59,5 +60,15 @@ public class JenkinsBasePointGeneratorTest {
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"\""));
         Assert.assertTrue(points[0].lineProtocol().contains("project_path=\"folder/master\""));
+    }
+
+    @Test
+    public void sheduled_and_start_and_end_time_present() {
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, StringUtils.EMPTY, build);
+        Point[] generatedPoints = generator.generate();
+
+        Assert.assertThat(generatedPoints[0].lineProtocol(), Matchers.containsString(String.format("%s=", JenkinsBasePointGenerator.BUILD_SCHEDULED_TIME)));
+        Assert.assertThat(generatedPoints[0].lineProtocol(), Matchers.containsString(String.format("%s=", JenkinsBasePointGenerator.BUILD_EXEC_TIME)));
+        Assert.assertThat(generatedPoints[0].lineProtocol(), Matchers.containsString(String.format("%s=", JenkinsBasePointGenerator.BUILD_MEASURED_TIME)));
     }
 }


### PR DESCRIPTION
- build_scheduled_time (build job is scheduled/triggered)
- build_exec_time (build job is actually running in an executor)
- build_measured_time (Point is created)