### PR TITLE
Setting test_name to tag instead of field so that the 'group by' clause can be used

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
@@ -114,7 +114,7 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
 
     private Point generateTestPoint(Test test) {
         Point.Builder builder = buildPoint(measurementName("perfpublisher_test"), customPrefix, build)
-                .addField("test_name", test.getName())
+                .tag("test_name", test.getName())
                 .addField("successful", test.isSuccessfull())
                 .addField("executed", test.isExecuted());
 
@@ -141,7 +141,7 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
             Metric metric = entry.getValue();
 
             Point point = buildPoint(measurementName("perfpublisher_test_metric"), customPrefix, build)
-                    .addField("test_name", test.getName())
+                    .tag("test_name", test.getName())
                     .addField("metric_name", metricName)
                     .addField("value", metric.getMeasure())
                     .addField("unit", metric.getUnit())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
@@ -114,6 +114,7 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
 
     private Point generateTestPoint(Test test) {
         Point.Builder builder = buildPoint(measurementName("perfpublisher_test"), customPrefix, build)
+                .addField("test_name", test.getName())
                 .tag("test_name", test.getName())
                 .addField("successful", test.isSuccessfull())
                 .addField("executed", test.isExecuted());
@@ -141,6 +142,7 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
             Metric metric = entry.getValue();
 
             Point point = buildPoint(measurementName("perfpublisher_test_metric"), customPrefix, build)
+                    .addField("test_name", test.getName())
                     .tag("test_name", test.getName())
                     .addField("metric_name", metricName)
                     .addField("value", metric.getMeasure())

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -87,10 +87,10 @@ public class PerfPublisherPointGeneratorTest {
         reports.addReport(report);
         PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build);
         Point[] points = generator.generate();
-
-        Assert.assertTrue(points[0].lineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master build_number=11i,number_of_executed_tests=1i"));
+        
+        Assert.assertTrue(points[0].lineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master build_number=11i,number_of_executed_tests=1i,number_of_failed_tests=1i"));
         Assert.assertTrue(points[1].lineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
-        Assert.assertTrue(points[2].lineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
-        Assert.assertTrue(points[3].lineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
+        Assert.assertTrue(points[2].lineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false"));
+        Assert.assertTrue(points[3].lineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,unit=\"ms\",value=50.0"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -88,9 +88,9 @@ public class PerfPublisherPointGeneratorTest {
         PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build);
         Point[] points = generator.generate();
         
-        Assert.assertTrue(points[0].lineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master build_number=11i,number_of_executed_tests=1i,number_of_failed_tests=1i"));
+        Assert.assertTrue(points[0].lineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master build_number=11i,number_of_executed_tests=1i"));
         Assert.assertTrue(points[1].lineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
-        Assert.assertTrue(points[2].lineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false"));
-        Assert.assertTrue(points[3].lineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,unit=\"ms\",value=50.0"));
+        Assert.assertTrue(points[2].lineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
+        Assert.assertTrue(points[3].lineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
     }
 }


### PR DESCRIPTION
This pull request sets 'test_name' for the PerfPublisher Plugin to use a tag. This allows the "group by" clause to be used when querying, so that individual test results can be graphed in Grafana/Chronograf by test name.