### PR TITLE
Add measurement name option

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -139,8 +139,14 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
     /**
      * custom measurement name used for all measurement types
+     * Overrides the default measurement names.
+     * Default value is "jenkins_data"
+     * 
+     * For custom data, prepends "custom_", i.e. "some_measurement"
+     * becomes "custom_some_measurement".
+     * Default custom name remains "jenkins_custom_data"
      */
-    private String customMeasurementName = "jenkins_data";
+    private String measurementName = "jenkins_data";
 
     @DataBoundConstructor
     public InfluxDbPublisher() {
@@ -238,12 +244,12 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     public Map<String, Map<String, String>> getCustomDataMapTags() { return customDataMapTags; }
 
     @DataBoundSetter
-    public void setCustomMeasurementName(String customMeasurementName) {
-        this.customMeasurementName = customMeasurementName;
+    public void setMeasurementName(String measurementName) {
+        this.measurementName = measurementName;
     }
 
-    public String getCustomMeasurementName() {
-        return customMeasurementName;
+    public String getMeasurementName() {
+        return measurementName;
     }
 
     public Target getTarget() {
@@ -325,10 +331,10 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         // finally write to InfluxDB
-        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag, customMeasurementName);
+        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag, measurementName);
         addPoints(pointsToWrite, jGen, listener);
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData, customDataTags, customMeasurementName);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData, customDataTags, measurementName);
         if (cdGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -137,6 +137,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
     private Map<String, Map<String, String>> customDataMapTags;
 
+    /**
+     * custom measurement name used for all measurement types
+     */
+    private String customMeasurementName = "jenkins_data";
+
     @DataBoundConstructor
     public InfluxDbPublisher() {
     }
@@ -232,6 +237,15 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
     public Map<String, Map<String, String>> getCustomDataMapTags() { return customDataMapTags; }
 
+    @DataBoundSetter
+    public void setCustomMeasurementName(String customMeasurementName) {
+        this.customMeasurementName = customMeasurementName;
+    }
+
+    public String getCustomMeasurementName() {
+        return customMeasurementName;
+    }
+
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();
         if (selectedTarget == null && targets.length > 0) {
@@ -311,10 +325,10 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         // finally write to InfluxDB
-        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag);
+        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag, customMeasurementName);
         addPoints(pointsToWrite, jGen, listener);
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData, customDataTags);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData, customDataTags, customMeasurementName);
         if (cdGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -12,16 +12,18 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
+    private final String measurementName;
     Map<String, Object> customData;
     Map<String, String> customDataTags;
 
     public CustomDataPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
-                                    Run<?, ?> build, Map customData, Map<String, String> customDataTags) {
+                                    Run<?, ?> build, Map customData, Map<String, String> customDataTags, String measurementName) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customData = customData;
         this.customDataTags = customDataTags;
+        this.measurementName = measurementName.equals("jenkins_data") ? "jenkins_custom_data" : "custom_" + measurementName;
     }
 
     public boolean hasReport() {
@@ -33,7 +35,7 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
         long currTime = System.currentTimeMillis();
         long dt = currTime - startTime;
 
-        Point.Builder pointBuilder = buildPoint(measurementName("jenkins_custom_data"), customPrefix, build)
+        Point.Builder pointBuilder = buildPoint(measurementName(measurementName), customPrefix, build)
                 .addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
                 .fields(customData);
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -23,6 +23,7 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
         this.customPrefix = customPrefix;
         this.customData = customData;
         this.customDataTags = customDataTags;
+        // Extra logic to retain compatibility with existing "jenkins_custom_data" tables
         this.measurementName = measurementName.equals("jenkins_data") ? "jenkins_custom_data" : "custom_" + measurementName;
     }
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -53,14 +53,16 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     private final TaskListener listener;
     private final String jenkinsEnvParameterField;
     private final String jenkinsEnvParameterTag;
+    private final String measurementName;
 
-    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix, Run<?, ?> build, TaskListener listener, String jenkinsEnvParameterField, String jenkinsEnvParameterTag) {
+    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix, Run<?, ?> build, TaskListener listener, String jenkinsEnvParameterField, String jenkinsEnvParameterTag, String measurementName ) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.listener = listener;
         this.jenkinsEnvParameterField = jenkinsEnvParameterField;
         this.jenkinsEnvParameterTag = jenkinsEnvParameterTag;
+        this.measurementName = measurementName;
     }
 
     public boolean hasReport() {
@@ -84,7 +86,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             ordinal = build.getResult().ordinal;
         }
 
-        Point.Builder point = buildPoint(measurementName("jenkins_data"), customPrefix, build);
+        Point.Builder point = buildPoint(measurementName(measurementName), customPrefix, build);
 
         point.addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
             .addField(BUILD_SCHEDULED_TIME, build.getTimeInMillis())

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -18,6 +18,7 @@ public class CustomDataPointGeneratorTest {
     public static final String JOB_NAME = "master";
     public static final int BUILD_NUMBER = 11;
     public static final String CUSTOM_PREFIX = "test_prefix";
+    public static final String MEASUREMENT_NAME = "jenkins_data";
 
     private Run<?,?> build;
     private Job job;
@@ -40,11 +41,11 @@ public class CustomDataPointGeneratorTest {
     @Test
     public void hasReportTest() {
         //check with customDataMap = null
-        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null, null);
+        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null, null, MEASUREMENT_NAME);
         Assert.assertFalse(cdGen1.hasReport());
 
         //check with empty customDataMap
-        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap(), null);
+        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap(), null, MEASUREMENT_NAME);
         Assert.assertFalse(cdGen2.hasReport());
     }
 
@@ -61,7 +62,7 @@ public class CustomDataPointGeneratorTest {
 
         List<Point> pointsToWrite = new ArrayList<Point>();
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData, customDataTags);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData, customDataTags, MEASUREMENT_NAME);
         pointsToWrite.addAll(Arrays.asList(cdGen.generate()));
 
         String lineProtocol = pointsToWrite.get(0).lineProtocol();

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -69,4 +69,22 @@ public class CustomDataPointGeneratorTest {
         Assert.assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,tag1=myTag build_number=11i,build_time="));
         Assert.assertTrue(lineProtocol.indexOf("project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i")>0);
     }
+
+    @Test
+    public void custom_measurement_included() {
+        String customMeasurement = "custom_measurement";
+        Map<String, Object> customData = new HashMap<String, Object>();
+        customData.put("test1", 11);
+
+        Map<String, String> customDataTags = new HashMap<String, String>();
+        customDataTags.put("tag1", "myTag");
+
+        List<Point> pointsToWrite = new ArrayList<Point>();
+
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData, customDataTags, customMeasurement);
+        pointsToWrite.addAll(Arrays.asList(cdGen.generate()));
+
+        String lineProtocol = pointsToWrite.get(0).lineProtocol();
+        Assert.assertTrue(lineProtocol.startsWith("custom_" + customMeasurement));
+    }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -42,6 +42,7 @@ public class JenkinsBasePointGeneratorTest {
                     "testEnvKeyTag2=PREFIX_${testEnvValueTag}_${testEnvValueTag}_SUFFIX";
     private static final String JENKINS_ENV_VALUE_TAG = "testEnvValueTag";
     private static final String JENKINS_ENV_RESOLVED_VALUE_TAG = "resolvedEnvValueTag";
+    public static final String MEASUREMENT_NAME = "jenkins_data";
 
     private Run<?, ?> build;
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
@@ -75,7 +76,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void agent_present() {
         Mockito.when(build.getExecutor()).thenReturn(executor);
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY, MEASUREMENT_NAME);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"slave-1\""));
@@ -85,7 +86,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void agent_not_present() {
         Mockito.when(build.getExecutor()).thenReturn(null);
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY, MEASUREMENT_NAME);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"\""));
@@ -94,7 +95,7 @@ public class JenkinsBasePointGeneratorTest {
 
     @Test
     public void sheduled_and_start_and_end_time_present() {
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, StringUtils.EMPTY, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, StringUtils.EMPTY, build, listener, StringUtils.EMPTY, StringUtils.EMPTY, MEASUREMENT_NAME);
         Point[] generatedPoints = generator.generate();
 
         Assert.assertThat(generatedPoints[0].lineProtocol(), Matchers.containsString(String.format("%s=", JenkinsBasePointGenerator.BUILD_SCHEDULED_TIME)));
@@ -106,7 +107,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void valid_jenkins_env_parameter_for_fields_present() {
         JenkinsBasePointGenerator jenkinsBasePointGenerator =
-                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, StringUtils.EMPTY);
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, StringUtils.EMPTY, MEASUREMENT_NAME);
         Point[] generatedPoints = jenkinsBasePointGenerator.generate();
         String lineProtocol = generatedPoints[0].lineProtocol();
 
@@ -126,7 +127,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void valid_jenkins_env_parameter_for_tags_present() {
         JenkinsBasePointGenerator jenkinsBasePointGenerator =
-                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, JENKINS_ENV_PARAMETER_TAG);
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, JENKINS_ENV_PARAMETER_TAG, MEASUREMENT_NAME);
         Point[] generatedPoints = jenkinsBasePointGenerator.generate();
         String lineProtocol = generatedPoints[0].lineProtocol();
 
@@ -146,7 +147,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void valid_jenkins_env_parameter_for_fields_and_tags_present() {
         JenkinsBasePointGenerator jenkinsBasePointGenerator =
-                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, JENKINS_ENV_PARAMETER_TAG);
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, JENKINS_ENV_PARAMETER_TAG, MEASUREMENT_NAME);
         Point[] generatedPoints = jenkinsBasePointGenerator.generate();
         String lineProtocol = generatedPoints[0].lineProtocol();
 

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -163,4 +163,15 @@ public class JenkinsBasePointGeneratorTest {
         assertThat(lineProtocol, containsString("testEnvKeyTag1=" + JENKINS_ENV_RESOLVED_VALUE_TAG));
         assertThat(lineProtocol, containsString("testEnvKeyTag2=PREFIX_" + JENKINS_ENV_RESOLVED_VALUE_TAG + "_" + JENKINS_ENV_RESOLVED_VALUE_TAG + "_SUFFIX"));
     }
+
+    @Test
+    public void custom_measurement_included() {
+        String customMeasurement = "custom_measurement";
+        JenkinsBasePointGenerator jenkinsBasePointGenerator =
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, JENKINS_ENV_PARAMETER_TAG, customMeasurement);
+        Point[] generatedPoints = jenkinsBasePointGenerator.generate();
+        String lineProtocol = generatedPoints[0].lineProtocol();
+
+        Assert.assertTrue(lineProtocol.startsWith(customMeasurement));
+    }
 }


### PR DESCRIPTION
Adds a measurementName option, which allows the user to set the measurement that values will be written to, allowing different Jenkins jobs (for example) to use the same database but different measurements.

Custom data measurements now have "custom_" prepended to them, with the exception of "jenkins_data", which retains the name "jenkins_custom_data" to maintain compatibility with existing installations.