### PR TITLE
Set a consistent timestamp for all point generation

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -292,8 +292,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
         MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
 
-        // Get the current time for timestamping all point generation
-        long currTime = System.currentTimeMillis();
+        // Get the current time for timestamping all point generation and convert to nanoseconds
+        long currTime = System.currentTimeMillis() * 1000000;
 
         // get the target from the job's config
         Target target = getTarget();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -272,6 +272,9 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
         MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
 
+        // Get the current time for timestamping all point generation
+        long currTime = System.currentTimeMillis();
+
         // get the target from the job's config
         Target target = getTarget();
         if (target==null) {
@@ -311,23 +314,23 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         // finally write to InfluxDB
-        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag);
+        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, currTime, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag);
         addPoints(pointsToWrite, jGen, listener);
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, customData, customDataTags);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, currTime, customData, customDataTags);
         if (cdGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);
         }
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, customDataMapTags);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, currTime, customDataMap, customDataMapTags);
         if (cdmGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);
         }
 
         try {
-            CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build);
+            CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build, currTime);
             if (cGen.hasReport()) {
                 listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, cGen, listener);
@@ -337,7 +340,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         }
 
         try {
-            RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build);
+            RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build, currTime);
             if (rfGen.hasReport()) {
                 listener.getLogger().println("[InfluxDB Plugin] Robot Framework data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, rfGen, listener);
@@ -347,7 +350,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         }
 
         try {
-            JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build);
+            JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build, currTime);
             if (jacoGen.hasReport()) {
                 listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, jacoGen, listener);
@@ -357,7 +360,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         }
 
         try {
-            PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build);
+            PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build, currTime);
             if (perfGen.hasReport()) {
                 listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, perfGen, listener);
@@ -366,21 +369,21 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             logger.log(Level.INFO, "Plugin skipped: Performance");
         }
 
-        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, listener);
+        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, currTime, listener);
         if (sonarGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, sonarGen, listener);
         }
 
 
-        ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build);
+        ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build, currTime);
         if (changeLogGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, changeLogGen, listener);
         }
 
         try {
-            PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build);
+            PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build, currTime);
             if (perfPublisherGen.hasReport()) {
                 listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, perfPublisherGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -32,7 +32,8 @@ public abstract class AbstractPointGenerator implements PointGenerator {
                 .addField(PROJECT_PATH, build.getParent().getRelativeNameFrom(Jenkins.getInstance()))
                 .addField(BUILD_NUMBER, build.getNumber())
                 .tag(PROJECT_NAME, renderedProjectName)
-                .time(this.timestamp, TimeUnit.MICROSECONDS);
+                // convert to nanoseconds for backwards compatability
+                .time(timestamp * 1000000, TimeUnit.NANOSECONDS);
 
         if (customPrefix != null && !customPrefix.isEmpty())
             builder = builder.tag(CUSTOM_PREFIX, measurementName(customPrefix));

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -6,6 +6,7 @@ import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import org.influxdb.dto.Point;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public abstract class AbstractPointGenerator implements PointGenerator {
 
@@ -13,11 +14,13 @@ public abstract class AbstractPointGenerator implements PointGenerator {
     public static final String PROJECT_PATH = "project_path";
     public static final String BUILD_NUMBER = "build_number";
     public static final String CUSTOM_PREFIX = "prefix";
+    public long timestamp;
 
     private MeasurementRenderer projectNameRenderer;
 
-    public AbstractPointGenerator(MeasurementRenderer projectNameRenderer) {
+    public AbstractPointGenerator(MeasurementRenderer projectNameRenderer, long timestamp) {
         this.projectNameRenderer = Objects.requireNonNull(projectNameRenderer);
+        this.timestamp = timestamp;
     }
 
     @Override
@@ -28,7 +31,8 @@ public abstract class AbstractPointGenerator implements PointGenerator {
                 .addField(PROJECT_NAME, renderedProjectName)
                 .addField(PROJECT_PATH, build.getParent().getRelativeNameFrom(Jenkins.getInstance()))
                 .addField(BUILD_NUMBER, build.getNumber())
-                .tag(PROJECT_NAME, renderedProjectName);
+                .tag(PROJECT_NAME, renderedProjectName)
+                .time(this.timestamp, TimeUnit.MICROSECONDS);
 
         if (customPrefix != null && !customPrefix.isEmpty())
             builder = builder.tag(CUSTOM_PREFIX, measurementName(customPrefix));

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -24,7 +24,7 @@ public abstract class AbstractPointGenerator implements PointGenerator {
     }
 
     @Override
-    public Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build) {
+    public Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build, long timestamp) {
         final String renderedProjectName = projectNameRenderer.render(build);
         Point.Builder builder = Point
                 .measurement(name)
@@ -32,14 +32,17 @@ public abstract class AbstractPointGenerator implements PointGenerator {
                 .addField(PROJECT_PATH, build.getParent().getRelativeNameFrom(Jenkins.getInstance()))
                 .addField(BUILD_NUMBER, build.getNumber())
                 .tag(PROJECT_NAME, renderedProjectName)
-                // convert to nanoseconds for backwards compatability
-                .time(timestamp * 1000000, TimeUnit.NANOSECONDS);
+                .time(timestamp, TimeUnit.NANOSECONDS);
 
         if (customPrefix != null && !customPrefix.isEmpty())
             builder = builder.tag(CUSTOM_PREFIX, measurementName(customPrefix));
 
         return builder;
 
+    }
+
+    public Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build) {
+        return buildPoint(name, customPrefix, build, timestamp);
     }
 
     protected String measurementName(String measurement) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/ChangeLogPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/ChangeLogPointGenerator.java
@@ -26,8 +26,8 @@ public class ChangeLogPointGenerator extends AbstractPointGenerator {
 	private int commitCount = 0;
 
 	public ChangeLogPointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix,
-			Run<?, ?> build) {
-		super(projectNameRenderer);
+			Run<?, ?> build, long timestamp) {
+		super(projectNameRenderer, timestamp);
 		this.build = build;
 		this.customPrefix = customPrefix;
 	}

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CoberturaPointGenerator.java
@@ -24,8 +24,8 @@ public class CoberturaPointGenerator extends AbstractPointGenerator {
     private final CoberturaBuildAction coberturaBuildAction;
     private final String customPrefix;
 
-    public CoberturaPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build) {
-        super(projectNameRenderer);
+    public CoberturaPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, long timestamp) {
+        super(projectNameRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         coberturaBuildAction = build.getAction(CoberturaBuildAction.class);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -16,9 +16,9 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
     Map<String, Map<String, String>> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
-                                       Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
+                                       Run<?, ?> build, long timestamp, Map<String, Map<String, Object>> customDataMap,
                                        Map<String, Map<String, String>> customDataMapTags) {
-        super(projectNameRenderer);
+        super(projectNameRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customDataMap = customDataMap;

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -16,8 +16,8 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
     Map<String, String> customDataTags;
 
     public CustomDataPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
-                                    Run<?, ?> build, Map customData, Map<String, String> customDataTags) {
-        super(projectNameRenderer);
+                                    Run<?, ?> build, long timestamp, Map customData, Map<String, String> customDataTags) {
+        super(projectNameRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customData = customData;
@@ -30,8 +30,7 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
 
     public Point[] generate() {
         long startTime = build.getTimeInMillis();
-        long currTime = System.currentTimeMillis();
-        long dt = currTime - startTime;
+        long dt = this.timestamp - startTime;
 
         Point.Builder pointBuilder = buildPoint(measurementName("jenkins_custom_data"), customPrefix, build)
                 .addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -30,7 +30,7 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
 
     public Point[] generate() {
         long startTime = build.getTimeInMillis();
-        long dt = this.timestamp - startTime;
+        long dt = timestamp - startTime;
 
         Point.Builder pointBuilder = buildPoint(measurementName("jenkins_custom_data"), customPrefix, build)
                 .addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
@@ -19,8 +19,8 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     private final String customPrefix;
     private final JacocoBuildAction jacocoBuildAction;
 
-    public JacocoPointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build) {
-        super(measurementRenderer);
+    public JacocoPointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build, long timestamp) {
+        super(measurementRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         jacocoBuildAction = build.getAction(JacocoBuildAction.class);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -54,8 +54,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     private final String jenkinsEnvParameterField;
     private final String jenkinsEnvParameterTag;
 
-    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix, Run<?, ?> build, TaskListener listener, String jenkinsEnvParameterField, String jenkinsEnvParameterTag) {
-        super(projectNameRenderer);
+    public JenkinsBasePointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix, Run<?, ?> build, long timestamp, TaskListener listener, String jenkinsEnvParameterField, String jenkinsEnvParameterTag) {
+        super(projectNameRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         this.listener = listener;

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
@@ -24,7 +24,7 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
         this.build = build;
         this.customPrefix = customPrefix;
         performanceBuildAction = build.getAction(PerfPublisherBuildAction.class);
-        timeGenerator = new TimeGenerator();
+        timeGenerator = new TimeGenerator(timestamp);
     }
 
     public boolean hasReport() {
@@ -35,7 +35,7 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
     public Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build) {
         // add unique time to guarantee correct point adding to DB
         return super.buildPoint(name, customPrefix, build)
-                .time(timeGenerator.getTimeNanos(), TimeUnit.NANOSECONDS);
+                .time(timeGenerator.next(), TimeUnit.NANOSECONDS);
     }
 
     public Point[] generate() {
@@ -153,24 +153,5 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
             pointsList.add(point);
         }
         return pointsList;
-    }
-
-    // generates unique nano timestamps
-    private static class TimeGenerator {
-        private final long nanoTimeShift;
-        private long lastReportedTime = 0;
-
-        TimeGenerator() {
-            nanoTimeShift = System.currentTimeMillis() * 1000000 - System.nanoTime();
-        }
-
-        long getTimeNanos() {
-            long timeToReport = System.nanoTime() + nanoTimeShift;
-            if (timeToReport <= lastReportedTime) {
-                timeToReport = lastReportedTime + 1;
-            }
-            lastReportedTime = timeToReport;
-            return timeToReport;
-        }
     }
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGenerator.java
@@ -19,8 +19,8 @@ public class PerfPublisherPointGenerator extends AbstractPointGenerator {
     private final PerfPublisherBuildAction performanceBuildAction;
     private final TimeGenerator timeGenerator;
 
-    public PerfPublisherPointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build) {
-        super(measurementRenderer);
+    public PerfPublisherPointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build, long timestamp) {
+        super(measurementRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         performanceBuildAction = build.getAction(PerfPublisherBuildAction.class);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PerformancePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PerformancePointGenerator.java
@@ -26,8 +26,8 @@ public class PerformancePointGenerator extends AbstractPointGenerator {
     private final String customPrefix;
     private final PerformanceBuildAction performanceBuildAction;
 
-    public PerformancePointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build) {
-        super(measurementRenderer);
+    public PerformancePointGenerator(MeasurementRenderer<Run<?,?>> measurementRenderer, String customPrefix, Run<?, ?> build, long timestamp) {
+        super(measurementRenderer, timestamp);
         this.build = build;
         this.customPrefix = customPrefix;
         performanceBuildAction = build.getAction(PerformanceBuildAction.class);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/PointGenerator.java
@@ -10,6 +10,11 @@ public interface PointGenerator {
     public Point[] generate();
 
     /**
+     * Initializes a basic build point with the basic data already set with a specified timestamp.
+     */
+    Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build, long timeStamp);
+
+    /**
      * Initializes a basic build point with the basic data already set.
      */
     Point.Builder buildPoint(String name, String customPrefix, Run<?, ?> build);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -35,8 +35,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     private final Map<String, RobotTagResult> tagResults;
     private MeasurementRenderer<Run<?,?>> projectNameRenderer;
 
-    public RobotFrameworkPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build) {
-        super(projectNameRenderer);
+    public RobotFrameworkPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, long timestamp) {
+        super(projectNameRenderer, timestamp);
         this.projectNameRenderer = projectNameRenderer;
         this.build = build;
         this.customPrefix = customPrefix;

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -78,31 +78,26 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
 
     private List<Point> generateSubPoints(RobotResult robotResult) {
         List<Point> subPoints = new ArrayList<Point>();
+        TimeGenerator suiteResultTime = new TimeGenerator(timestamp);
         for(RobotSuiteResult suiteResult : robotResult.getAllSuites()) {
-            subPoints.add(generateSuitePoint(suiteResult));
-
+            long caseTimeStamp = suiteResultTime.next();
+            subPoints.add(generateSuitePoint(suiteResult, caseTimeStamp));
+            // To preserve the existing functionality of the case being timestamps after the
+            // suiteResult, seed the new TimeGenerator with the suiteResult's time
+            TimeGenerator caseResultTime = new TimeGenerator(caseTimeStamp);
             for(RobotCaseResult caseResult : suiteResult.getAllCases()) {
-                Point casePoint = generateCasePoint(caseResult);
+                Point casePoint = generateCasePoint(caseResult, caseResultTime.next());
                 if (casePointExists(subPoints, casePoint)) {
                     continue;
                 }
-                subPoints.add(generateCasePoint(caseResult));
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException ie) {
-                    // handle
-                }
+                subPoints.add(casePoint);
             }
 
         }
 
+        TimeGenerator tagTime = new TimeGenerator(timestamp);
         for(Map.Entry<String, RobotTagResult> entry : tagResults.entrySet()) {
-            subPoints.add(generateTagPoint(entry.getValue()));
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ie) {
-                // handle
-            }
+            subPoints.add(generateTagPoint(entry.getValue(), tagTime.next()));
         }
         return subPoints;
     }
@@ -123,8 +118,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         return false;
     }
 
-    private Point generateCasePoint(RobotCaseResult caseResult) {
-        Point point = buildPoint(measurementName("testcase_point"), customPrefix, build)
+    private Point generateCasePoint(RobotCaseResult caseResult, long timestamp) {
+        Point point = buildPoint(measurementName("testcase_point"), customPrefix, build, timestamp)
             .field(RF_NAME, caseResult.getName())
             .field(RF_SUITE_NAME, caseResult.getParent().getName())
             .field(RF_CRITICAL_FAILED, caseResult.getCriticalFailed())
@@ -169,8 +164,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         }
     }
 
-    private Point generateTagPoint(RobotTagResult tagResult) {
-        Point point = buildPoint(measurementName("tag_point"), customPrefix, build)
+    private Point generateTagPoint(RobotTagResult tagResult, long timestamp) {
+        Point point = buildPoint(measurementName("tag_point"), customPrefix, build, timestamp)
             .field(RF_TAG_NAME, tagResult.name)
             .field(RF_CRITICAL_FAILED, tagResult.criticalFailed)
             .field(RF_CRITICAL_PASSED, tagResult.criticalPassed)
@@ -184,8 +179,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         return point;
     }
 
-    private Point generateSuitePoint(RobotSuiteResult suiteResult) {
-        Point point = buildPoint(measurementName("suite_result"), customPrefix, build)
+    private Point generateSuitePoint(RobotSuiteResult suiteResult, long timestamp) {
+        Point point = buildPoint(measurementName("suite_result"), customPrefix, build, timestamp)
             .field(RF_SUITE_NAME, suiteResult.getName())
             .field(RF_TESTCASES, suiteResult.getAllCases().size())
             .field(RF_CRITICAL_FAILED, suiteResult.getCriticalFailed())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -51,8 +51,8 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 	private final TaskListener listener;
 
 	public SonarQubePointGenerator(MeasurementRenderer<Run<?, ?>> measurementRenderer, String customPrefix,
-			Run<?, ?> build, TaskListener listener) {
-		super(measurementRenderer);
+			Run<?, ?> build, long timestamp, TaskListener listener) {
+		super(measurementRenderer, timestamp);
 		this.build = build;
 		this.customPrefix = customPrefix;
 		this.listener = listener;

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/TimeGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/TimeGenerator.java
@@ -1,0 +1,15 @@
+package jenkinsci.plugins.influxdb.generators;
+
+public class TimeGenerator {
+    private final long currentTime;
+    private long nanoOffSet = 0;
+
+    TimeGenerator(long currentTime) {
+        this.currentTime = currentTime;
+    }
+
+    public long next() {
+        nanoOffSet++;
+        return currentTime + nanoOffSet;
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -24,6 +24,8 @@ public class CustomDataMapPointGeneratorTest {
 
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
 
+    private long currTime;
+
     @Before
     public void before() {
         build = Mockito.mock(Run.class);
@@ -35,24 +37,25 @@ public class CustomDataMapPointGeneratorTest {
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
         Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
 
+        
+        currTime = System.currentTimeMillis();
     }
 
     @Test
     public void hasReportTest() {
         //check with customDataMap = null
         CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
-                null, null);
+                currTime, null, null);
         Assert.assertFalse(cdmGen1.hasReport());
 
         //check with empty customDataMap
         CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
-                Collections.<String, Map<String, Object>>emptyMap(), Collections.<String, Map<String, String>>emptyMap());
+                currTime, Collections.<String, Map<String, Object>>emptyMap(), Collections.<String, Map<String, String>>emptyMap());
         Assert.assertFalse(cdmGen2.hasReport());
     }
 
     @Test
     public void generateTest() {
-
         Map<String, Object> customData1 = new HashMap<String, Object>();
         customData1.put("test1", 11);
         customData1.put("test2", 22);
@@ -76,7 +79,7 @@ public class CustomDataMapPointGeneratorTest {
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
-                customDataMap, customDataMapTags);
+                currTime, customDataMap, customDataMapTags);
         pointsToWrite.addAll(Arrays.asList(cdmGen.generate()));
 
         String lineProtocol1;

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -24,6 +24,8 @@ public class CustomDataPointGeneratorTest {
 
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
 
+    private long currTime;
+
     @Before
     public void before() {
         build = Mockito.mock(Run.class);
@@ -35,16 +37,17 @@ public class CustomDataPointGeneratorTest {
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
         Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
 
+        currTime = System.currentTimeMillis();
     }
 
     @Test
     public void hasReportTest() {
         //check with customDataMap = null
-        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null, null);
+        CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, null, null);
         Assert.assertFalse(cdGen1.hasReport());
 
         //check with empty customDataMap
-        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap(), null);
+        CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, Collections.<String, Map<String, Object>>emptyMap(), null);
         Assert.assertFalse(cdGen2.hasReport());
     }
 
@@ -61,7 +64,7 @@ public class CustomDataPointGeneratorTest {
 
         List<Point> pointsToWrite = new ArrayList<Point>();
 
-        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customData, customDataTags);
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, customData, customDataTags);
         pointsToWrite.addAll(Arrays.asList(cdGen.generate()));
 
         String lineProtocol = pointsToWrite.get(0).lineProtocol();

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -49,6 +49,8 @@ public class JenkinsBasePointGeneratorTest {
     private TaskListener listener;
     private EnvVars mockedEnvVars;
 
+    private long currTime;
+
     @Before
     public void before() throws IOException, InterruptedException {
         build = Mockito.mock(Run.class);
@@ -70,12 +72,14 @@ public class JenkinsBasePointGeneratorTest {
         Mockito.when(job.getBuildHealth()).thenReturn(new HealthReport());
         Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_FIELD)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_FIELD);
         Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_TAG)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_TAG);
+        
+        currTime = System.currentTimeMillis();
     }
 
     @Test
     public void agent_present() {
         Mockito.when(build.getExecutor()).thenReturn(executor);
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, currTime, listener, StringUtils.EMPTY, StringUtils.EMPTY);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"slave-1\""));
@@ -85,7 +89,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void agent_not_present() {
         Mockito.when(build.getExecutor()).thenReturn(null);
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, AbstractPointGenerator.CUSTOM_PREFIX, build, currTime, listener, StringUtils.EMPTY, StringUtils.EMPTY);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().contains("build_agent_name=\"\""));
@@ -94,7 +98,7 @@ public class JenkinsBasePointGeneratorTest {
 
     @Test
     public void sheduled_and_start_and_end_time_present() {
-        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, StringUtils.EMPTY, build, listener, StringUtils.EMPTY, StringUtils.EMPTY);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(measurementRenderer, StringUtils.EMPTY, build, currTime, listener, StringUtils.EMPTY, StringUtils.EMPTY);
         Point[] generatedPoints = generator.generate();
 
         Assert.assertThat(generatedPoints[0].lineProtocol(), Matchers.containsString(String.format("%s=", JenkinsBasePointGenerator.BUILD_SCHEDULED_TIME)));
@@ -106,7 +110,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void valid_jenkins_env_parameter_for_fields_present() {
         JenkinsBasePointGenerator jenkinsBasePointGenerator =
-                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, StringUtils.EMPTY);
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, listener, JENKINS_ENV_PARAMETER_FIELD, StringUtils.EMPTY);
         Point[] generatedPoints = jenkinsBasePointGenerator.generate();
         String lineProtocol = generatedPoints[0].lineProtocol();
 
@@ -126,7 +130,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void valid_jenkins_env_parameter_for_tags_present() {
         JenkinsBasePointGenerator jenkinsBasePointGenerator =
-                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, StringUtils.EMPTY, JENKINS_ENV_PARAMETER_TAG);
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, listener, StringUtils.EMPTY, JENKINS_ENV_PARAMETER_TAG);
         Point[] generatedPoints = jenkinsBasePointGenerator.generate();
         String lineProtocol = generatedPoints[0].lineProtocol();
 
@@ -146,7 +150,7 @@ public class JenkinsBasePointGeneratorTest {
     @Test
     public void valid_jenkins_env_parameter_for_fields_and_tags_present() {
         JenkinsBasePointGenerator jenkinsBasePointGenerator =
-                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, listener, JENKINS_ENV_PARAMETER_FIELD, JENKINS_ENV_PARAMETER_TAG);
+                new JenkinsBasePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, listener, JENKINS_ENV_PARAMETER_FIELD, JENKINS_ENV_PARAMETER_TAG);
         Point[] generatedPoints = jenkinsBasePointGenerator.generate();
         String lineProtocol = generatedPoints[0].lineProtocol();
 

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -34,6 +34,8 @@ public class PerfPublisherPointGeneratorTest {
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
     private ReportContainer reports;
 
+    private long currTime;
+
     @Before
     public void before() {
         build = Mockito.mock(Run.class);
@@ -55,15 +57,17 @@ public class PerfPublisherPointGeneratorTest {
             }
         });
         Mockito.when(buildAction.getReports()).thenReturn(reports);
+
+        currTime = System.currentTimeMillis();
     }
 
     @Test
     public void hasReportTest() {
-        PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build);
+        PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime);
         Assert.assertFalse(generator.hasReport());
 
         reports.addReport(new Report());
-        generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build);
+        generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime);
         Assert.assertTrue(generator.hasReport());
     }
 
@@ -85,7 +89,7 @@ public class PerfPublisherPointGeneratorTest {
 
         report.addTest(test);
         reports.addReport(report);
-        PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build);
+        PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime);
         Point[] points = generator.generate();
 
         Assert.assertTrue(points[0].lineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master build_number=11i,number_of_executed_tests=1i"));

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
@@ -22,7 +22,9 @@ public class SonarQubePointGeneratorTest {
 	    private Run build;
 	    private Job job;
 
-	    private MeasurementRenderer<Run<?, ?>> measurementRenderer;
+		private MeasurementRenderer<Run<?, ?>> measurementRenderer;
+		
+		private long currTime;
 
 	    @Before
 	    public void before() {
@@ -34,13 +36,14 @@ public class SonarQubePointGeneratorTest {
 	        Mockito.when(build.getParent()).thenReturn(job);
 	        Mockito.when(job.getName()).thenReturn(JOB_NAME);
 
+			currTime = System.currentTimeMillis();
 	    }
 	
 	@Test
 	public void getSonarProjectNameTest() throws URISyntaxException {
 		String name = "org.namespace:feature%2Fmy-sub-project";
 		String url = "http://sonar.dashboard.com/dashboard/index/" + name;
-		SonarQubePointGenerator gen = new SonarQubePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null);
+		SonarQubePointGenerator gen = new SonarQubePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, null);
 		assertEquals(name, gen.getSonarProjectName(url));
 	}
 }


### PR DESCRIPTION
Sets a single timestamp across all point generation so that all points can be aggregated into a single point (i.e. in a Grafana display). Without this, each point would run a chance of having a different time set for it, periodically breaking this functionality.