### PR TITLE
Fix bug preventing setting target in pipeline step

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -163,8 +163,6 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             if (targets.length > 0) {
                 //ipTemp = targets[0].getUrl() + "," + targets[0].getDatabase();
                 ipTemp = targets[0].getDescription();
-            } else {
-                throw new RuntimeException("Target was null!");
             }
         }
         return ipTemp;
@@ -297,6 +295,9 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
         // get the target from the job's config
         Target target = getTarget();
+        if (target==null) {
+            throw new RuntimeException("Target was null!");
+        }
 
         // prepare a meaningful logmessage
         String logMessage = "[InfluxDB Plugin] Publishing data to: " + target.toString();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -163,6 +163,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             if (targets.length > 0) {
                 //ipTemp = targets[0].getUrl() + "," + targets[0].getDatabase();
                 ipTemp = targets[0].getDescription();
+            } else {
+                throw new RuntimeException("Target was null!");
             }
         }
         return ipTemp;
@@ -295,9 +297,6 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
         // get the target from the job's config
         Target target = getTarget();
-        if (target==null) {
-            throw new RuntimeException("Target was null!");
-        }
 
         // prepare a meaningful logmessage
         String logMessage = "[InfluxDB Plugin] Publishing data to: " + target.toString();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -168,6 +168,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         return ipTemp;
     }
 
+    @DataBoundSetter
     public void setSelectedTarget(String target) {
         Preconditions.checkNotNull(target);
         this.selectedTarget = target;


### PR DESCRIPTION
Bug that arises if you have multiple targets - only the first one can be set, as it will default to it if the target isn't specified. This was occurring due to a missing `@DataBoundSetter`.