### PR TITLE
Custom timestamps

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -57,6 +57,12 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     private String customPrefix;
 
     /**
+     * custom timestamp, enabling you to have a build that produces historical data. For example haveing 
+     * a build that pulls data from a separate API.
+     */
+    private String customTimeStamp;
+
+    /**
      * Jenkins parameter/s which will be added as FieldSet to measurement 'jenkins_data'.
      * If parameter-value has a $-prefix, it will be resolved from current jenkins-job environment-properties.
      */
@@ -191,6 +197,15 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         this.customPrefix = customPrefix;
     }
 
+    public String getCustomTimeStamp() {
+        return customTimeStamp;
+    }
+
+    @DataBoundSetter
+    public void setCustomTimeStamp(String customTimeStamp) {
+        this.customTimeStamp = customTimeStamp;
+    }
+
     public String getJenkinsEnvParameterField() {
         return jenkinsEnvParameterField;
     }
@@ -291,9 +306,14 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             throws InterruptedException, IOException {
 
         MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
-
-        // Get the current time for timestamping all point generation
-        long currTime = System.currentTimeMillis();
+        
+        long currTime;
+        if (customTimeStamp == null) {
+            // Get the current time for timestamping all point generation
+            currTime = System.currentTimeMillis();
+        } else {
+            currTime = Long.parseLong(customTimeStamp, 10);
+        }
 
         // get the target from the job's config
         Target target = getTarget();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -65,6 +65,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     /**
      * Jenkins parameter/s which will be added as FieldSet to measurement 'jenkins_data'.
      * If parameter-value has a $-prefix, it will be resolved from current jenkins-job environment-properties.
+     * Expects a millisecond timestamp, which can be passed as a string or to customTimeStampLong as a long.
      */
     private String jenkinsEnvParameterField;
 

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -210,6 +210,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         this.customTimeStamp = Long.parseLong(customTimeStamp, 10);
     }
 
+    @DataBoundSetter
+    public void setCustomTimeStamp(long customTimeStamp) {
+        this.customTimeStamp = customTimeStamp;
+    }
+
     public String getJenkinsEnvParameterField() {
         return jenkinsEnvParameterField;
     }

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -211,7 +211,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
-    public void setCustomTimeStamp(long customTimeStamp) {
+    public void setCustomTimeStampLong(long customTimeStamp) {
         this.customTimeStamp = customTimeStamp;
     }
 

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -60,7 +60,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      * custom timestamp, enabling you to have a build that produces historical data. For example haveing 
      * a build that pulls data from a separate API.
      */
-    private long customTimeStamp;
+    private long customTimestamp;
 
     /**
      * Jenkins parameter/s which will be added as FieldSet to measurement 'jenkins_data'.
@@ -199,21 +199,21 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     public long getCustomTimeStamp() {
-        if (customTimeStamp == 0) {
+        if (customTimestamp == 0) {
             return System.currentTimeMillis();
         } else {
-            return customTimeStamp;
+            return customTimestamp;
         }
     }
 
     @DataBoundSetter
-    public void setCustomTimeStamp(String customTimeStamp) {
-        this.customTimeStamp = Long.parseLong(customTimeStamp, 10);
+    public void setCustomTimestamp(String customTimestamp) {
+        this.customTimestamp = Long.parseLong(customTimestamp, 10);
     }
 
     @DataBoundSetter
-    public void setCustomTimeStampLong(long customTimeStamp) {
-        this.customTimeStamp = customTimeStamp;
+    public void setCustomTimestampLong(long customTimestamp) {
+        this.customTimestamp = customTimestamp;
     }
 
     public String getJenkinsEnvParameterField() {

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -60,7 +60,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      * custom timestamp, enabling you to have a build that produces historical data. For example haveing 
      * a build that pulls data from a separate API.
      */
-    private String customTimeStamp;
+    private long customTimeStamp;
 
     /**
      * Jenkins parameter/s which will be added as FieldSet to measurement 'jenkins_data'.
@@ -197,13 +197,17 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         this.customPrefix = customPrefix;
     }
 
-    public String getCustomTimeStamp() {
-        return customTimeStamp;
+    public long getCustomTimeStamp() {
+        if (customTimeStamp == 0) {
+            return System.currentTimeMillis();
+        } else {
+            return customTimeStamp;
+        }
     }
 
     @DataBoundSetter
     public void setCustomTimeStamp(String customTimeStamp) {
-        this.customTimeStamp = customTimeStamp;
+        this.customTimeStamp = Long.parseLong(customTimeStamp, 10);
     }
 
     public String getJenkinsEnvParameterField() {
@@ -307,13 +311,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
         MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
         
-        long currTime;
-        if (customTimeStamp == null) {
-            // Get the current time for timestamping all point generation
-            currTime = System.currentTimeMillis();
-        } else {
-            currTime = Long.parseLong(customTimeStamp, 10);
-        }
+        // Get the time for timestamping all point generation
+        long currTime = getCustomTimeStamp();
 
         // get the target from the job's config
         Target target = getTarget();

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
@@ -24,6 +24,9 @@
            <f:entry title="jenkins-env-parameter TagSet" field="jenkinsEnvParameterTag">
                <f:textarea name="publisherBinding.jenkinsEnvParameterTag" value="${publisherBinding.jenkinsEnvParameterTag}"/>
            </f:entry>
+            <f:entry title="customTimestamp" field="customTimestamp">
+               <f:textarea name="publisherBinding.customTimestamp" value="${publisherBinding.customTimestamp}"/>
+           </f:entry>
        </f:advanced>
   </f:section>
 


### PR DESCRIPTION
Simple change to allow a custom timestamp to be set.
The use-case envisioned is to allow populating an InfluxDB database with historical data from another source, but can also be used to specify what part of the build the timestamp should come from (such as in #37).
