### PR TITLE
Fix for NullpointerException in CustomPointDataGenerator (default measurementName) in latest release 1.18

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -39,6 +39,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     /** The logger. **/
     private static final Logger logger = Logger.getLogger(InfluxDbPublisher.class.getName());
 
+    public static final String DEFAULT_MEASUREMENT_NAME = "jenkins_data";
+
     @Extension(optional = true)
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
@@ -146,7 +148,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      * becomes "custom_some_measurement".
      * Default custom name remains "jenkins_custom_data"
      */
-    private String measurementName = "jenkins_data";
+    private String measurementName;
 
     @DataBoundConstructor
     public InfluxDbPublisher() {
@@ -253,6 +255,10 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         return measurementName;
     }
 
+    private String getMeasurementNameIfNotBlankOrDefault() {
+        return measurementName != null ? measurementName : DEFAULT_MEASUREMENT_NAME;
+    }
+
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();
         if (selectedTarget == null && targets.length > 0) {
@@ -329,6 +335,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             }
             builder.build();
         }
+
+        String measurementName = getMeasurementNameIfNotBlankOrDefault();
 
         // connect to InfluxDB
         InfluxDB influxDB = Strings.isNullOrEmpty(target.getUsername()) ? InfluxDBFactory.connect(target.getUrl(), builder) : InfluxDBFactory.connect(target.getUrl(), target.getUsername(), target.getPassword(), builder);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -6,6 +6,8 @@ import org.influxdb.dto.Point;
 
 import java.util.Map;
 
+import static jenkinsci.plugins.influxdb.InfluxDbPublisher.DEFAULT_MEASUREMENT_NAME;
+
 public class CustomDataPointGenerator extends AbstractPointGenerator {
 
     public static final String BUILD_TIME = "build_time";
@@ -24,7 +26,7 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
         this.customData = customData;
         this.customDataTags = customDataTags;
         // Extra logic to retain compatibility with existing "jenkins_custom_data" tables
-        this.measurementName = measurementName.equals("jenkins_data") ? "jenkins_custom_data" : "custom_" + measurementName;
+        this.measurementName = DEFAULT_MEASUREMENT_NAME.equals(measurementName) ? "jenkins_custom_data" : "custom_" + measurementName;
     }
 
     public boolean hasReport() {


### PR DESCRIPTION
When InfluxDbPublisher is instantiated, the default member measurementName = "jenkins_data" is overwritten.
This leads to a NullpointerException in CustomPointDataGenerator:

```
14:28:03 [InfluxDB Plugin] Failed to collect data. Ignoring Exception:java.lang.NullPointerException
14:28:03 ERROR: Build step failed with exception
14:28:03 java.lang.NullPointerException
14:28:03 	at jenkinsci.plugins.influxdb.generators.CustomDataPointGenerator.<init>(CustomDataPointGenerator.java:27)
14:28:03 	at jenkinsci.plugins.influxdb.InfluxDbPublisher.perform(InfluxDbPublisher.java:341)
14:28:03 	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
14:28:03 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
14:28:03 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:735)
14:28:03 	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:676)
14:28:03 	at hudson.model.Build$BuildExecution.cleanUp(Build.java:196)
14:28:03 	at hudson.model.Run.execute(Run.java:1782)
14:28:03 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
14:28:03 	at hudson.model.ResourceController.execute(ResourceController.java:97)
14:28:03 	at hudson.model.Executor.run(Executor.java:405)
```

