### PR TITLE
Add possibility to configure the scheduled job time as InfluxDB points timestamp

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -294,7 +294,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
 
         // Get the current time for timestamping all point generation and convert to nanoseconds
-        long currTime = System.currentTimeMillis() * 1000000;
+        long currTime = resolveTimestampForPointGenerationInNanoseconds(build);
 
         // get the target from the job's config
         Target target = getTarget();
@@ -423,6 +423,14 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
 
         writeToInflux(target, influxDB, pointsToWrite);
         listener.getLogger().println("[InfluxDB Plugin] Completed.");
+    }
+
+    private long resolveTimestampForPointGenerationInNanoseconds(final Run<?, ?> build) {
+        long timestamp = System.currentTimeMillis();
+        if (getTarget().isJobScheduledTimeAsPointsTimestamp()) {
+            timestamp = build.getTimeInMillis();
+        }
+        return timestamp * 1000000;
     }
 
     private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -8,6 +8,7 @@ public class Target {
     String password;
     String database;
     String retentionPolicy;
+    boolean jobScheduledTimeAsPointsTimestamp;
     boolean exposeExceptions;
     boolean usingJenkinsProxy;
 
@@ -61,6 +62,14 @@ public class Target {
 
     public void setRetentionPolicy(String retentionPolicy) {
         this.retentionPolicy = retentionPolicy;
+    }
+
+    public boolean isJobScheduledTimeAsPointsTimestamp() {
+        return jobScheduledTimeAsPointsTimestamp;
+    }
+
+    public void setJobScheduledTimeAsPointsTimestamp(boolean jobScheduledTimeAsPointsTimestamp) {
+        this.jobScheduledTimeAsPointsTimestamp = jobScheduledTimeAsPointsTimestamp;
     }
 
     public boolean isExposeExceptions() {

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -35,6 +35,10 @@
                          <f:textbox name="targetBinding.retentionPolicy" value="${currentTarget.retentionPolicy}" default="autogen" />
                       </f:entry>
 
+                      <f:entry title="job scheduled time as points timestamp" field="jobScheduledTimeAsPointsTimestamp" >
+                         <f:checkbox name="targetBinding.jobScheduledTimeAsPointsTimestamp" checked="${currentTarget.jobScheduledTimeAsPointsTimestamp}" default="false" />
+                      </f:entry>
+
                       <f:entry title="exposeExceptions" field="exposeExceptions" >
                          <f:checkbox name="targetBinding.exposeExceptions" checked="${currentTarget.exposeExceptions}" default="true" />
                       </f:entry>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jobScheduledTimeAsPointsTimestamp.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jobScheduledTimeAsPointsTimestamp.html
@@ -1,0 +1,1 @@
+If activated, the time when a job is scheduled is set as timestamp for every InfluxDB point instead of the time, when the point is created (and the job is almost done).


### PR DESCRIPTION
Add possibility to configure the scheduled job time as InfluxDB points timestamp in the global configuration.

The original behaviour (points timestamp is time when point is created; job is in postprocess) is set as default.
