### PR TITLE
Sending metrics for all builds (V2)

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -253,7 +253,7 @@ public class InfluxDbPublicationService {
         // Writes into each selected target
         for (Target selectedTarget : selectedTargets) {
             // prepare a meaningful logmessage
-            String logMessage = "[InfluxDB Plugin] Publishing data to: " + selectedTargets;
+            String logMessage = "[InfluxDB Plugin] Publishing data to: " + selectedTarget;
             // write to jenkins logger
             logger.log(Level.FINE, logMessage);
             // write to jenkins console

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -1,0 +1,302 @@
+package jenkinsci.plugins.influxdb;
+
+import com.google.common.base.Strings;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkinsci.plugins.influxdb.generators.*;
+import jenkinsci.plugins.influxdb.models.Target;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDB.ConsistencyLevel;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class InfluxDbPublicationService {
+
+    /**
+     * The logger.
+     **/
+    private static final Logger logger = Logger.getLogger(InfluxDbPublicationService.class.getName());
+
+    /**
+     * List of targets to write to
+     */
+    private List<Target> selectedTargets;
+
+    /**
+     * custom project name, overrides the project name with the specified value
+     */
+    private String customProjectName;
+
+    /**
+     * custom prefix, for example in multi branch pipelines, where every build is named
+     * after the branch built and thus you have different builds called 'master' that report
+     * different metrics.
+     */
+    private String customPrefix;
+
+
+    /**
+     * custom data, especially in pipelines, where additional information is calculated
+     * or retrieved by Groovy functions which should be sent to InfluxDB
+     * This can easily be done by calling
+     * <p>
+     * def myDataMap = [:]+
+     * myDataMap['myKey'] = 'myValue'
+     * step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData: myDataMap])
+     * <p>
+     * inside a pipeline script
+     */
+    private Map<String, Object> customData;
+
+
+    /**
+     * custom data tags, especially in pipelines, where additional information is calculated
+     * or retrieved by Groovy functions which should be sent to InfluxDB
+     * This can easily be done by calling
+     *
+     *   def myDataMapTags = [:]
+     *   myDataMapTags['myKey'] = 'myValue'
+     *   step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customData: myDataMap, customDataTags: myDataMapTags])
+     *
+     * inside a pipeline script
+     */
+    private final Map<String, String> customDataTags;
+
+    /**
+     * custom tags that are sent to all measurements defined in customDataMaps.
+     *
+     * Example for a pipeline script:
+     *
+     * def myCustomDataMapTags = [:]
+     * def myCustomTags = [:]
+     * myCustomTags["buildResult"] = currentBuild.result
+     * myCustomTags["NODE_LABELS"] = env.NODE_LABELS
+     * myCustomDataMapTags["series1"] = myCustomTags
+     * step([$class: 'InfluxDbPublisher',
+     *       target: myTarget,
+     *       customPrefix: 'myPrefix',
+     *       customDataMap: myCustomDataMap,
+     *       customDataMapTags: myCustomDataMapTags])
+     */
+
+    private final Map<String, Map<String, String>> customDataMapTags;
+
+    /**
+     * custom data maps, especially in pipelines, where additional information is calculated
+     * or retrieved by Groovy functions which should be sent to InfluxDB.
+     * <p>
+     * This goes beyond customData since it allows to define multiple customData measurements
+     * where the name of the measurement is defined as the key of the customDataMap.
+     * <p>
+     * Example for a pipeline script:
+     * <p>
+     * def myDataMap1 = [:]
+     * def myDataMap2 = [:]
+     * def myCustomDataMap = [:]
+     * myDataMap1["myMap1Key1"] = 11 //first value of first map
+     * myDataMap1["myMap1Key2"] = 12 //second value of first map
+     * myDataMap2["myMap2Key1"] = 21 //first value of second map
+     * myDataMap2["myMap2Key2"] = 22 //second value of second map
+     * myCustomDataMap["series1"] = myDataMap1
+     * myCustomDataMap["series2"] = myDataMap2
+     * step([$class: 'InfluxDbPublisher', target: myTarget, customPrefix: 'myPrefix', customDataMap: myCustomDataMap])
+     */
+    private Map<String, Map<String, Object>> customDataMap;
+
+    private final long timestamp;
+
+    /**
+     * Jenkins parameter/s which will be added as FieldSet to measurement 'jenkins_data'.
+     * If parameter-value has a $-prefix, it will be resolved from current jenkins-job environment-properties.
+     */
+    private final String jenkinsEnvParameterField;
+
+    /**
+     * Jenkins parameter/s which will be added as TagSet to  measurement 'jenkins_data'.
+     * If parameter-value has a $-prefix, it will be resolved from current jenkins-job environment-properties.
+     */
+    private final String jenkinsEnvParameterTag;
+
+    /**
+     * custom measurement name used for all measurement types
+     * Overrides the default measurement names.
+     * Default value is "jenkins_data"
+     *
+     * For custom data, prepends "custom_", i.e. "some_measurement"
+     * becomes "custom_some_measurement".
+     * Default custom name remains "jenkins_custom_data"
+     */
+    private final String measurementName;
+
+    public InfluxDbPublicationService(List<Target> selectedTargets, String customProjectName, String customPrefix, Map<String, Object> customData, Map<String, String> customDataTags, Map<String, Map<String, String>> customDataMapTags, Map<String, Map<String, Object>> customDataMap, long timestamp, String jenkinsEnvParameterField, String jenkinsEnvParameterTag, String measurementName) {
+        this.selectedTargets = selectedTargets;
+        this.customProjectName = customProjectName;
+        this.customPrefix = customPrefix;
+        this.customData = customData;
+        this.customDataTags = customDataTags;
+        this.customDataMapTags = customDataMapTags;
+        this.customDataMap = customDataMap;
+        this.timestamp = timestamp;
+        this.jenkinsEnvParameterField = jenkinsEnvParameterField;
+        this.jenkinsEnvParameterTag = jenkinsEnvParameterTag;
+        this.measurementName = measurementName;
+    }
+
+    public void perform(Run<?, ?> build, TaskListener listener) {
+
+        // Logging
+        listener.getLogger().println("[InfluxDB Plugin] Collecting data for publication in InfluxDB...");
+
+        // Renderer to use for the metrics
+        MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
+
+        // Points to write
+        List<Point> pointsToWrite = new ArrayList<Point>();
+
+        // Basic metrics
+        JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(measurementRenderer, customPrefix, build, timestamp, listener, jenkinsEnvParameterField, jenkinsEnvParameterTag, measurementName);
+        addPoints(pointsToWrite, jGen, listener);
+
+        CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, timestamp, customData, customDataTags, measurementName);
+        if (cdGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, cdGen, listener);
+        } else {
+            logger.log(Level.INFO, "Data source empty: Custom Data");
+        }
+
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, timestamp, customDataMap, customDataMapTags);
+        if (cdmGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, cdmGen, listener);
+        } else {
+            logger.log(Level.INFO, "Data source empty: Custom Data Map");
+        }
+
+        try {
+            CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build, timestamp);
+            if (cGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, cGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Cobertura");
+        }
+
+        try {
+            RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build, timestamp);
+            if (rfGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Robot Framework data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, rfGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Robot Framework");
+        }
+
+        try {
+            JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build, timestamp);
+            if (jacoGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, jacoGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: JaCoCo");
+        }
+
+        try {
+            PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build, timestamp);
+            if (perfGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, perfGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Performance");
+        }
+
+        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, timestamp, listener);
+        if (sonarGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, sonarGen, listener);
+        } else {
+            logger.log(Level.INFO, "Plugin skipped: SonarQube");
+        }
+
+
+        ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build, timestamp);
+        if (changeLogGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, changeLogGen, listener);
+        } else {
+            logger.log(Level.INFO, "Data source empty: Change Log");
+        }
+
+        try {
+            PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build, timestamp);
+            if (perfPublisherGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, perfPublisherGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.INFO, "Plugin skipped: Performance Publisher");
+        }
+
+        // Writes into each selected target
+        for (Target selectedTarget : selectedTargets) {
+            // prepare a meaningful logmessage
+            String logMessage = "[InfluxDB Plugin] Publishing data to: " + selectedTargets;
+            // write to jenkins logger
+            logger.log(Level.INFO, logMessage);
+            // write to jenkins console
+            listener.getLogger().println(logMessage);
+            // connect to InfluxDB
+            InfluxDB influxDB = Strings.isNullOrEmpty(selectedTarget.getUsername()) ?
+                    InfluxDBFactory.connect(selectedTarget.getUrl()) :
+                    InfluxDBFactory.connect(selectedTarget.getUrl(), selectedTarget.getUsername(), selectedTarget.getPassword());
+            // Sending points to the target
+            writeToInflux(selectedTarget, influxDB, pointsToWrite);
+        }
+
+        // We're done
+        listener.getLogger().println("[InfluxDB Plugin] Completed.");
+    }
+
+    private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {
+        try {
+            pointsToWrite.addAll(Arrays.asList(generator.generate()));
+        } catch (Exception e) {
+            listener.getLogger().println("[InfluxDB Plugin] Failed to collect data. Ignoring Exception:" + e);
+        }
+    }
+
+    private void writeToInflux(Target target, InfluxDB influxDB, List<Point> pointsToWrite) {
+        /*
+         * build batchpoints for a single write.
+         */
+        try {
+            BatchPoints batchPoints = BatchPoints
+                    .database(target.getDatabase())
+                    .points(pointsToWrite.toArray(new Point[0]))
+                    .retentionPolicy(target.getRetentionPolicy())
+                    .consistency(ConsistencyLevel.ANY)
+                    .build();
+            influxDB.write(batchPoints);
+        } catch (Exception e) {
+            if (target.isExposeExceptions()) {
+                throw new InfluxReportException(e);
+            } else {
+                //Exceptions not exposed by configuration. Just log and ignore.
+                logger.log(Level.WARNING, "Could not report to InfluxDB. Ignoring Exception.", e);
+            }
+        }
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -172,7 +172,7 @@ public class InfluxDbPublicationService {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);
         } else {
-            logger.log(Level.INFO, "Data source empty: Custom Data");
+            logger.log(Level.FINE, "Data source empty: Custom Data");
         }
 
         CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, timestamp, customDataMap, customDataMapTags);
@@ -180,7 +180,7 @@ public class InfluxDbPublicationService {
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);
         } else {
-            logger.log(Level.INFO, "Data source empty: Custom Data Map");
+            logger.log(Level.FINE, "Data source empty: Custom Data Map");
         }
 
         try {
@@ -190,7 +190,7 @@ public class InfluxDbPublicationService {
                 addPoints(pointsToWrite, cGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Cobertura");
+            logger.log(Level.FINE, "Plugin skipped: Cobertura");
         }
 
         try {
@@ -200,7 +200,7 @@ public class InfluxDbPublicationService {
                 addPoints(pointsToWrite, rfGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Robot Framework");
+            logger.log(Level.FINE, "Plugin skipped: Robot Framework");
         }
 
         try {
@@ -210,7 +210,7 @@ public class InfluxDbPublicationService {
                 addPoints(pointsToWrite, jacoGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: JaCoCo");
+            logger.log(Level.FINE, "Plugin skipped: JaCoCo");
         }
 
         try {
@@ -220,7 +220,7 @@ public class InfluxDbPublicationService {
                 addPoints(pointsToWrite, perfGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Performance");
+            logger.log(Level.FINE, "Plugin skipped: Performance");
         }
 
         SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, timestamp, listener);
@@ -228,7 +228,7 @@ public class InfluxDbPublicationService {
             listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, sonarGen, listener);
         } else {
-            logger.log(Level.INFO, "Plugin skipped: SonarQube");
+            logger.log(Level.FINE, "Plugin skipped: SonarQube");
         }
 
 
@@ -237,7 +237,7 @@ public class InfluxDbPublicationService {
             listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, changeLogGen, listener);
         } else {
-            logger.log(Level.INFO, "Data source empty: Change Log");
+            logger.log(Level.FINE, "Data source empty: Change Log");
         }
 
         try {
@@ -247,7 +247,7 @@ public class InfluxDbPublicationService {
                 addPoints(pointsToWrite, perfPublisherGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Performance Publisher");
+            logger.log(Level.FINE, "Plugin skipped: Performance Publisher");
         }
 
         // Writes into each selected target
@@ -255,7 +255,7 @@ public class InfluxDbPublicationService {
             // prepare a meaningful logmessage
             String logMessage = "[InfluxDB Plugin] Publishing data to: " + selectedTargets;
             // write to jenkins logger
-            logger.log(Level.INFO, logMessage);
+            logger.log(Level.FINE, logMessage);
             // write to jenkins console
             listener.getLogger().println(logMessage);
             // connect to InfluxDB

--- a/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
@@ -1,0 +1,88 @@
+package jenkinsci.plugins.influxdb.global;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import jenkins.model.Jenkins;
+import jenkinsci.plugins.influxdb.InfluxDbPublicationService;
+import jenkinsci.plugins.influxdb.InfluxDbPublisher;
+import jenkinsci.plugins.influxdb.models.Target;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Listens to call builds being completed, and publishes their metrics
+ * in InfluxDB.
+ */
+@Extension
+public class GlobalRunListener extends RunListener<Run<?, ?>> {
+
+    @Override
+    public void onCompleted(Run<?, ?> build, @Nonnull TaskListener listener) {
+        // Gets the full path of the build's project
+        String path = build.getParent().getRelativeNameFrom(Jenkins.getInstance());
+        // Gets the list of targets from the configuration
+        Target[] targets = InfluxDbPublisher.DESCRIPTOR.getTargets();
+        if (targets != null) {
+            // Selects the targets eligible as global listeners and which match the build path
+            List<Target> selectedTargets = new ArrayList<>();
+            for (Target target : targets) {
+                // Checks if the target matches the path to the project
+                // Skip build if it already publishes information on this target
+                if (isTargetMatchingPath(target, path) && !isPublicationInBuild(target, build)) {
+                    selectedTargets.add(target);
+                }
+            }
+            // If some targets are selected
+            if (!selectedTargets.isEmpty()) {
+                // Creates the publication service
+                InfluxDbPublicationService publicationService = new InfluxDbPublicationService(
+                        selectedTargets,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        System.currentTimeMillis() * 1000000,
+                        null,
+                        null,
+                        "jenkins_data"
+                );
+                // Publication
+                publicationService.perform(build, listener);
+            }
+        }
+    }
+
+    private boolean isPublicationInBuild(Target target, Run<?, ?> build) {
+        Job<?, ?> parent = build.getParent();
+        if (parent instanceof AbstractProject) {
+            InfluxDbPublisher publisher = (InfluxDbPublisher) ((AbstractProject) parent).getPublishersList().get(InfluxDbPublisher.class);
+            if (publisher != null) {
+                String buildTarget = publisher.getSelectedTarget();
+                return buildTarget != null && StringUtils.equals(buildTarget, target.getDescription());
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isTargetMatchingPath(@Nonnull Target target, @Nonnull String path) {
+        if (target.isGlobalListener()) {
+            String pattern = target.getGlobalListenerFilter();
+            return StringUtils.isBlank(pattern) || Pattern.matches(pattern, path);
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -11,6 +11,8 @@ public class Target implements java.io.Serializable {
     boolean jobScheduledTimeAsPointsTimestamp;
     boolean exposeExceptions;
     boolean usingJenkinsProxy;
+    boolean globalListener;
+    String globalListenerFilter;
 
     public Target(){
         //nop
@@ -86,6 +88,22 @@ public class Target implements java.io.Serializable {
 
     public void setUsingJenkinsProxy(boolean usingJenkinsProxy) {
         this.usingJenkinsProxy = usingJenkinsProxy;
+    }
+
+    public boolean isGlobalListener() {
+        return globalListener;
+    }
+
+    public void setGlobalListener(boolean globalListener) {
+        this.globalListener = globalListener;
+    }
+
+    public String getGlobalListenerFilter() {
+        return globalListenerFilter;
+    }
+
+    public void setGlobalListenerFilter(String globalListenerFilter) {
+        this.globalListenerFilter = globalListenerFilter;
     }
 
     @Override

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/global.jelly
@@ -47,6 +47,14 @@
                          <f:checkbox name="targetBinding.usingJenkinsProxy" checked="${currentTarget.usingJenkinsProxy}" default="false" />
                       </f:entry>
 
+                      <f:entry title="globalListener" field="globalListener" >
+                         <f:checkbox name="targetBinding.globalListener" checked="${currentTarget.globalListener}" default="false" />
+                      </f:entry>
+
+                      <f:entry title="globalListenerFilter" field="globalListenerFilter" >
+                         <f:textbox name="targetBinding.globalListenerFilter" value="${currentTarget.globalListenerFilter}" default="" />
+                      </f:entry>
+
                       <f:entry title="delete target" >
                         <div align="right">
                           <f:repeatableDeleteButton value="delete target"/>


### PR DESCRIPTION
Rewriting of the #27 pull request on top on the latest version, since refactoring made the conflict resolution too risky.

For clarity, I repeat the description of the PR here:

This PR allows to flag some targets (an InfluxDB database) to listen at all build completions in Jenkins and to send its metrics to the target.

* the target can be flagged to send metrics for all builds (by default: no, like today)
* the target can be associated with a regular expression to match only some project paths (by default: all of them)
* the global metrics to a given target are not sent if the project is already associated with a publication for this target (to avoid sending the same metrics to the same target twice)
* the code of the `InfluxDbPublisher` has been refactored to use the same code than some the global metrics

The rationale for this change is to allow a global setup of the metrics over all the jobs and projects of a Jenkins instance.

IMPORTANT: I consider this PR as highly experimental. While the previous one was tested OK in production, this is not the case for this one.

NOTE: I don't have time to improve the code, but I think the point generators should be handled using dependency injection and extensions. Not by listing them.

Best regards,
Damien.