### PR TITLE
Reduce verbosity in Jenkins system logs

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -306,7 +306,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
         String logMessage = "[InfluxDB Plugin] Publishing data to: " + target.toString();
 
         // write to jenkins logger
-        logger.log(Level.INFO, logMessage);
+        logger.log(Level.FINE, logMessage);
         // write to jenkins console
         listener.getLogger().println(logMessage);
 
@@ -343,7 +343,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);
         } else {
-            logger.log(Level.INFO, "Data source empty: Custom Data");
+            logger.log(Level.FINE, "Data source empty: Custom Data");
         }
 
         CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, currTime, customDataMap, customDataMapTags);
@@ -351,7 +351,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);
         } else {
-            logger.log(Level.INFO, "Data source empty: Custom Data Map");
+            logger.log(Level.FINE, "Data source empty: Custom Data Map");
         }
 
         try {
@@ -361,7 +361,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 addPoints(pointsToWrite, cGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Cobertura");
+            logger.log(Level.FINE, "Plugin skipped: Cobertura");
         }
 
         try {
@@ -371,7 +371,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 addPoints(pointsToWrite, rfGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Robot Framework");
+            logger.log(Level.FINE, "Plugin skipped: Robot Framework");
         }
 
         try {
@@ -381,7 +381,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 addPoints(pointsToWrite, jacoGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: JaCoCo");
+            logger.log(Level.FINE, "Plugin skipped: JaCoCo");
         }
 
         try {
@@ -391,7 +391,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 addPoints(pointsToWrite, perfGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Performance");
+            logger.log(Level.FINE, "Plugin skipped: Performance");
         }
 
         SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, currTime, listener);
@@ -399,7 +399,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, sonarGen, listener);
         } else {
-            logger.log(Level.INFO, "Plugin skipped: SonarQube");
+            logger.log(Level.FINE, "Plugin skipped: SonarQube");
         }
 
 
@@ -408,7 +408,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, changeLogGen, listener);
         } else {
-            logger.log(Level.INFO, "Data source empty: Change Log");
+            logger.log(Level.FINE, "Data source empty: Change Log");
         }
 
         try {
@@ -418,7 +418,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
                 addPoints(pointsToWrite, perfPublisherGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
-            logger.log(Level.INFO, "Plugin skipped: Performance Publisher");
+            logger.log(Level.FINE, "Plugin skipped: Performance Publisher");
         }
 
         writeToInflux(target, influxDB, pointsToWrite);


### PR DESCRIPTION
When used on a large Jenkins instance with many builds, these log statements pollute the logs.