### PR TITLE
Fix calculated build time in custom data by using System.currentTimeM…

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -35,7 +35,7 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
 
     public Point[] generate() {
         long startTime = build.getTimeInMillis();
-        long currTime = System.currentTimeMillis();
+        long currTime = timestamp / 1000000;
         long dt = currTime - startTime;
 
         Point.Builder pointBuilder = buildPoint(measurementName(measurementName), customPrefix, build)

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -35,7 +35,8 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
 
     public Point[] generate() {
         long startTime = build.getTimeInMillis();
-        long dt = timestamp - startTime;
+        long currTime = System.currentTimeMillis();
+        long dt = currTime - startTime;
 
         Point.Builder pointBuilder = buildPoint(measurementName(measurementName), customPrefix, build)
                 .addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGenerator.java
@@ -34,8 +34,8 @@ public class CustomDataPointGenerator extends AbstractPointGenerator {
     }
 
     public Point[] generate() {
-        long startTime = build.getTimeInMillis();
-        long currTime = timestamp / 1000000;
+        long startTime = timestamp / 1000000;
+        long currTime = System.currentTimeMillis();
         long dt = currTime - startTime;
 
         Point.Builder pointBuilder = buildPoint(measurementName(measurementName), customPrefix, build)


### PR DESCRIPTION
The calculated build time for custom data is terribly wrong for pipeline builds where the build is still running and the duration cannot be fetched from Jenkins itself. The timestamp provided to CustomDataPointGenerator used for the calculation is in nanoseconds while it is required to be in milliseconds. Since JenkinsBasePointGenerator is calculating the timestamp using System.currentTimeMillis(), I added that calculation here too. Alternatively, if the provided timestamp is supposed to be used although it isn't in the base point generation, the start time needs to be converted to nanoseconds before calculating the duration and the result converted back to milliseconds.