### PR TITLE
InfluxDbPublisher: avoid NullPointerException on empty targets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,10 +118,11 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.8.9</version>
             <scope>test</scope>
         </dependency>
 
@@ -141,10 +142,10 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito -->
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>1.7.4</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,31 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.8.4</version>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.7.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -15,7 +15,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import net.sf.json.JSONObject;
 
-public class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject, java.io.Serializable {
+public final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject, java.io.Serializable {
 
     private static final String DISPLAY_NAME = "Publish build data to InfluxDb target";
     private List<Target> targets = new CopyOnWriteArrayList<>();

--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -15,7 +15,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import net.sf.json.JSONObject;
 
-public final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject, java.io.Serializable {
+public class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject, java.io.Serializable {
 
     private static final String DISPLAY_NAME = "Publish build data to InfluxDb target";
     private List<Target> targets = new CopyOnWriteArrayList<>();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -311,14 +311,14 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
 
-        // Get the current time for timestamping all point generation and convert to nanoseconds
-        long currTime = resolveTimestampForPointGenerationInNanoseconds(build);
-
         // Gets the target from the job's config
         Target target = getTarget();
         if (target == null) {
             throw new RuntimeException("Target was null!");
         }
+
+        // Get the current time for timestamping all point generation and convert to nanoseconds
+        long currTime = resolveTimestampForPointGenerationInNanoseconds(build);
 
         measurementName = getMeasurementNameIfNotBlankOrDefault();
         // Preparing the service

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -1,0 +1,51 @@
+package jenkinsci.plugins.influxdb;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkinsci.plugins.influxdb.models.Target;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(InfluxDbPublisher.class)
+public class InfluxDbPublisherTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private FilePath workspace = new FilePath(new File("."));
+    @Mock
+    private Run build;
+    @Mock
+    private Launcher launcher;
+    @Mock
+    private TaskListener listener;
+
+    @Test
+    public void emptyTargetTest() throws Exception {
+        exception.expect(RuntimeException.class);
+        exception.expectMessage("Target was null!");
+
+        DescriptorImpl descriptorMock = Mockito.mock(DescriptorImpl.class);
+        Mockito.when(descriptorMock.getTargets()).thenReturn(new Target[0]);
+        PowerMockito.whenNew(DescriptorImpl.class).withNoArguments().thenReturn(descriptorMock);
+
+        try {
+            new InfluxDbPublisher().perform(build, workspace, launcher, listener);
+        } catch (NullPointerException e) {
+            Assert.fail("NullPointerException raised");
+        }
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -35,9 +35,8 @@ public class CustomDataMapPointGeneratorTest {
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getParent()).thenReturn(job);
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
-        Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
 
-        
         currTime = System.currentTimeMillis();
     }
 

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -36,7 +36,7 @@ public class CustomDataPointGeneratorTest {
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getParent()).thenReturn(job);
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
-        Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
 
         currTime = System.currentTimeMillis();
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -69,7 +69,7 @@ public class JenkinsBasePointGeneratorTest {
         Mockito.when(executor.getOwner()).thenReturn(computer);
         Mockito.when(computer.getName()).thenReturn("slave-1");
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
-        Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
         Mockito.when(job.getBuildHealth()).thenReturn(new HealthReport());
         Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_FIELD)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_FIELD);
         Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_TAG)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_TAG);

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -47,7 +47,7 @@ public class PerfPublisherPointGeneratorTest {
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getParent()).thenReturn(job);
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
-        Mockito.when(job.getRelativeNameFrom(Mockito.any(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
         Mockito.when(build.getAction(PerfPublisherBuildAction.class)).thenReturn(buildAction);
 
         Mockito.when(buildAction.getReport()).thenAnswer(new Answer<Report>() {

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
issue: `resolveTimestampForPointGenerationInNanoseconds()` already references `getTarget()` and runs into a NPE if no targets are found

- [x] write test case
- update `Mockito` dependency (to be aligned with `PowerMock`)


[JENKINS-55594](https://issues.jenkins-ci.org/browse/JENKINS-55594)