### PR TITLE
add @Symbol annotation

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
 
 import jenkinsci.plugins.influxdb.models.Target;
@@ -15,6 +16,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import net.sf.json.JSONObject;
 
+@Symbol("influxDb")
 public final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject, java.io.Serializable {
 
     private static final String DISPLAY_NAME = "Publish build data to InfluxDb target";

--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -16,7 +16,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import net.sf.json.JSONObject;
 
-@Symbol("influxDb")
+@Symbol("influxDbPublisher")
 public final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements ModelObject, java.io.Serializable {
 
     private static final String DISPLAY_NAME = "Publish build data to InfluxDb target";


### PR DESCRIPTION
**changes:**
- add `@Symbol` annotation to ease use

This makes it possible to call `influxDb(..)` in a pipeline instead of `step([$class: 'InfluxDbPublisher', ..])`

see https://jenkins.io/doc/developer/plugin-development/pipeline-integration/#defining-symbols