### PR TITLE
[JENKINS-53950] JCasC compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,13 @@ THE SOFTWARE.
         </dependency>
 
         <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.14</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>robot</artifactId>
             <version>1.6.0</version>

--- a/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/DescriptorImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import jenkinsci.plugins.influxdb.models.Target;
@@ -46,8 +47,9 @@ public final class DescriptorImpl extends BuildStepDescriptor<Publisher> impleme
         return targets.toArray(new Target[0]);
     }
 
-    public void setTargets(List newTargets) {
-        targets = newTargets;
+    @DataBoundSetter
+    public void setTargets(List<Target> targets) {
+        this.targets = targets;
     }
 
     @Override

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -1,8 +1,11 @@
 package jenkinsci.plugins.influxdb.models;
 
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class Target implements java.io.Serializable {
+public class Target extends AbstractDescribableImpl<Target> implements java.io.Serializable {
 
     private String description;
     private String url;
@@ -130,4 +133,7 @@ public class Target implements java.io.Serializable {
         return "[url=" + this.url + ", description=" + this.description + ", username=" + this.username
                 + ", password=*****, database=" + this.database + "]";
     }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<Target> {}
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/ConfigurationAsCodeTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/ConfigurationAsCodeTest.java
@@ -1,0 +1,77 @@
+package jenkinsci.plugins.influxdb;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import jenkinsci.plugins.influxdb.models.Target;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ConfigurationAsCodeTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void should_support_jcasc_from_yaml() throws Exception {
+        DescriptorImpl globalConfig = j.jenkins.getDescriptorByType(DescriptorImpl.class);
+
+        String yamlUrl = getClass().getResource(getClass().getSimpleName() + "/configuration-as-code.yml").toString();
+        ConfigurationAsCode.get().configure(yamlUrl);
+
+        assertThat(globalConfig.getTargets(), arrayWithSize(1));
+
+        Target target = globalConfig.getTargets()[0];
+        assertThat(target.getDescription(), equalTo("some description"));
+        assertThat(target.getUrl(), equalTo("http://some/url"));
+        assertThat(target.getUsername(), equalTo("some username"));
+        assertThat(target.getPassword(), equalTo("some password"));
+        assertThat(target.getDatabase(), equalTo("some_database"));
+        assertThat(target.getRetentionPolicy(), equalTo("some_policy"));
+        assertThat(target.isJobScheduledTimeAsPointsTimestamp(), equalTo(true));
+        assertThat(target.isExposeExceptions(), equalTo(true));
+        assertThat(target.isUsingJenkinsProxy(), equalTo(true));
+        assertThat(target.isGlobalListener(), equalTo(true));
+        assertThat(target.getGlobalListenerFilter(), equalTo("some filter"));
+    }
+
+    @Test
+    public void should_support_jcasc_to_yaml() throws Exception {
+        DescriptorImpl globalConfig = j.jenkins.getDescriptorByType(DescriptorImpl.class);
+
+        Target target = new Target();
+        target.setDescription("some description");
+        target.setUrl("http://some/url");
+        target.setUsername("some username");
+        target.setPassword("some password");
+        target.setDatabase("some_database");
+        target.setRetentionPolicy("some_policy");
+        target.setJobScheduledTimeAsPointsTimestamp(true);
+        target.setExposeExceptions(true);
+        target.setUsingJenkinsProxy(true);
+        target.setGlobalListener(true);
+        target.setGlobalListenerFilter("some filter");
+
+        globalConfig.setTargets(Collections.singletonList(target));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(outputStream);
+        String exportedYaml = outputStream.toString("UTF-8");
+
+        InputStream yamlStream = getClass().getResourceAsStream(getClass().getSimpleName() + "/configuration-as-code.yml");
+        String expectedYaml = IOUtils.toString(yamlStream, "UTF-8")
+                .replaceAll("\r\n?", "\n")
+                .replace("unclassified:\n", "");
+
+        assertThat(exportedYaml, containsString(expectedYaml));
+    }
+}

--- a/src/test/resources/jenkinsci/plugins/influxdb/ConfigurationAsCodeTest/configuration-as-code.yml
+++ b/src/test/resources/jenkinsci/plugins/influxdb/ConfigurationAsCodeTest/configuration-as-code.yml
@@ -1,0 +1,14 @@
+unclassified:
+  influxDbPublisher:
+    targets:
+    - database: "some_database"
+      description: "some description"
+      exposeExceptions: true
+      globalListener: true
+      globalListenerFilter: "some filter"
+      jobScheduledTimeAsPointsTimestamp: true
+      password: "some password"
+      retentionPolicy: "some_policy"
+      url: "http://some/url"
+      username: "some username"
+      usingJenkinsProxy: true


### PR DESCRIPTION
This adds support for configuration as code ([JENKINS-53950](https://issues.jenkins-ci.org/browse/JENKINS-53950)).