### PR TITLE
Fix parameter usage in ProjectNameRenderer

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRenderer.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRenderer.java
@@ -20,17 +20,17 @@ public class ProjectNameRenderer implements MeasurementRenderer<Run<?, ?>> {
     }
 
     protected String projectName(String prefix, String projectName, Run<?, ?> build) {
-        if (this.customProjectName == null) {
-            this.customProjectName = build.getParent().getName();
+        if (projectName == null) {
+            projectName = build.getParent().getName();
         }
         return Joiner
                 .on("_")
                 .skipNulls()
-                .join(Strings.emptyToNull(prefix), Strings.emptyToNull(this.customProjectName));
+                .join(Strings.emptyToNull(prefix), Strings.emptyToNull(projectName));
     }
 
     protected String measurementName(String measurement) {
-        //influx disallows "-" in measurement names.
+        // InfluxDB disallows "-" in measurement names.
         return measurement.replaceAll("-", "_");
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRendererTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRendererTest.java
@@ -56,4 +56,17 @@ public class ProjectNameRendererTest {
         String renderedProjectName = projectNameRenderer.render(build);
         Assert.assertTrue(renderedProjectName.startsWith("master"));
     }
+
+    @Test
+    public void nullProjectNameWithNullPrefix_NoSideEffects() {
+        ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(null, null);
+
+        Mockito.when(job.getName()).thenReturn("job 1");
+        String renderedProjectName1 = projectNameRenderer.render(build);
+        Assert.assertTrue(renderedProjectName1.startsWith("job 1"));
+
+        Mockito.when(job.getName()).thenReturn("job 2");
+        String renderedProjectName2 = projectNameRenderer.render(build);
+        Assert.assertTrue(renderedProjectName2.startsWith("job 2"));
+    }
 }


### PR DESCRIPTION
Otherwise the parameter `projectName` would be unused and calling
the method `projectName` would have unintended side effects. They
would be noticable when the method would be called multiple times.