### PR TITLE
JENKINS-47776 Added some verbosity to identify the cause

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -79,6 +79,8 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 			String url = "";
 			try {
 				url = build.getEnvironment(listener).get("SONAR_HOST_URL");
+                String logMessage = "[InfluxDB Plugin] INFO: Using SonarQube host URL found in environment variable SONAR_HOST_URL";
+                listener.getLogger().println(logMessage);
 			} catch (InterruptedException | IOException e) {
 				// handle
 			}
@@ -128,9 +130,14 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 		try {
 			String token = build.getEnvironment(listener).get("SONAR_AUTH_TOKEN");
 			if (token != null) {
+                String logMessage = "[InfluxDB Plugin] INFO: Using SonarQube auth token found in environment variable SONAR_AUTH_TOKEN";
+                listener.getLogger().println(logMessage);
 				String credential = Credentials.basic(token, "", StandardCharsets.UTF_8);
 				requestBuilder.header("Authorization", credential);
-			}
+			} else {
+                String logMessage = "[InfluxDB Plugin] WARNING: No SonarQube auth token found in environment variable SONAR_AUTH_TOKEN. Depending on access rights, this might result in a HTTP/401.";
+                listener.getLogger().println(logMessage);
+            }
 		} catch (InterruptedException | IOException e) {
 			// handle
 		}


### PR DESCRIPTION
Added warnings and info messages to identify missing SonarQube environment variables. This is NOT a fix for JENKINS-47776, it merely informs the user about environment variables it expects, but cannot find.