### PR TITLE
More consistent tests

### DIFF
--- a/src/test/java/jenkinsci/plugins/influxdb/ConfigurationAsCodeTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/ConfigurationAsCodeTest.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class ConfigurationAsCodeTest {
@@ -32,17 +32,17 @@ public class ConfigurationAsCodeTest {
         assertThat(globalConfig.getTargets(), arrayWithSize(1));
 
         Target target = globalConfig.getTargets()[0];
-        assertThat(target.getDescription(), equalTo("some description"));
-        assertThat(target.getUrl(), equalTo("http://some/url"));
-        assertThat(target.getUsername(), equalTo("some username"));
-        assertThat(target.getPassword(), equalTo(Secret.fromString("some password")));
-        assertThat(target.getDatabase(), equalTo("some_database"));
-        assertThat(target.getRetentionPolicy(), equalTo("some_policy"));
-        assertThat(target.isJobScheduledTimeAsPointsTimestamp(), equalTo(true));
-        assertThat(target.isExposeExceptions(), equalTo(true));
-        assertThat(target.isUsingJenkinsProxy(), equalTo(true));
-        assertThat(target.isGlobalListener(), equalTo(true));
-        assertThat(target.getGlobalListenerFilter(), equalTo("some filter"));
+        assertThat(target.getDescription(), is("some description"));
+        assertThat(target.getUrl(), is("http://some/url"));
+        assertThat(target.getUsername(), is("some username"));
+        assertThat(target.getPassword(), is(Secret.fromString("some password")));
+        assertThat(target.getDatabase(), is("some_database"));
+        assertThat(target.getRetentionPolicy(), is("some_policy"));
+        assertThat(target.isJobScheduledTimeAsPointsTimestamp(), is(true));
+        assertThat(target.isExposeExceptions(), is(true));
+        assertThat(target.isUsingJenkinsProxy(), is(true));
+        assertThat(target.isGlobalListener(), is(true));
+        assertThat(target.getGlobalListenerFilter(), is("some filter"));
     }
 
     @Test

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -34,7 +34,7 @@ public class InfluxDbPublisherTest {
     private TaskListener listener;
 
     @Test
-    public void emptyTargetTest() throws Exception {
+    public void emptyTarget() throws Exception {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Target was null!");
 

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -6,21 +6,25 @@ import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.influxdb.dto.Point;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 public class CustomDataMapPointGeneratorTest {
 
-    public static final String JOB_NAME = "master";
-    public static final int BUILD_NUMBER = 11;
-    public static final String CUSTOM_PREFIX = "test_prefix";
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
 
     private Run<?,?> build;
-    private Job job;
 
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
 
@@ -29,7 +33,7 @@ public class CustomDataMapPointGeneratorTest {
     @Before
     public void before() {
         build = Mockito.mock(Run.class);
-        job = Mockito.mock(Job.class);
+        Job job = Mockito.mock(Job.class);
         measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
 
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
@@ -41,20 +45,20 @@ public class CustomDataMapPointGeneratorTest {
     }
 
     @Test
-    public void hasReportTest() {
+    public void hasReport() {
         //check with customDataMap = null
         CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
                 currTime, null, null, true);
-        Assert.assertFalse(cdmGen1.hasReport());
+        assertThat(cdmGen1.hasReport(), is(false));
 
         //check with empty customDataMap
         CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
                 currTime, Collections.emptyMap(), Collections.emptyMap(), true);
-        Assert.assertFalse(cdmGen2.hasReport());
+        assertThat(cdmGen2.hasReport(), is(false));
     }
 
     @Test
-    public void generateTest() {
+    public void generate() {
         Map<String, Object> customData1 = new HashMap<>();
         customData1.put("test1", 11);
         customData1.put("test2", 22);
@@ -85,7 +89,7 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite[1].lineProtocol();
             lineProtocol2 = pointsToWrite[0].lineProtocol();
         }
-        Assert.assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
-        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test3=33i,test4=44i"));
+        assertThat(lineProtocol1, startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
+        assertThat(lineProtocol2, startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test3=33i,test4=44i"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -6,22 +6,27 @@ import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.influxdb.dto.Point;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 public class CustomDataPointGeneratorTest {
 
-    public static final String JOB_NAME = "master";
-    public static final int BUILD_NUMBER = 11;
-    public static final String CUSTOM_PREFIX = "test_prefix";
-    public static final String MEASUREMENT_NAME = "jenkins_data";
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
+    private static final String MEASUREMENT_NAME = "jenkins_data";
 
     private Run<?,?> build;
-    private Job job;
 
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
 
@@ -30,7 +35,7 @@ public class CustomDataPointGeneratorTest {
     @Before
     public void before() {
         build = Mockito.mock(Run.class);
-        job = Mockito.mock(Job.class);
+        Job job = Mockito.mock(Job.class);
         measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
 
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
@@ -42,18 +47,18 @@ public class CustomDataPointGeneratorTest {
     }
 
     @Test
-    public void hasReportTest() {
+    public void hasReport() {
         //check with customDataMap = null
         CustomDataPointGenerator cdGen1 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, null, null, MEASUREMENT_NAME, true);
-        Assert.assertFalse(cdGen1.hasReport());
+        assertThat(cdGen1.hasReport(), is(false));
 
         //check with empty customDataMap
         CustomDataPointGenerator cdGen2 = new CustomDataPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, Collections.<String, Map<String, Object>>emptyMap(), null, MEASUREMENT_NAME, true);
-        Assert.assertFalse(cdGen2.hasReport());
+        assertThat(cdGen2.hasReport(), is(false));
     }
 
     @Test
-    public void generateTest() {
+    public void generate() {
         Map<String, Object> customData = new HashMap<>();
         customData.put("test1", 11);
         customData.put("test2", 22);
@@ -65,8 +70,8 @@ public class CustomDataPointGeneratorTest {
         Point[] pointsToWrite = cdGen.generate();
 
         String lineProtocol = pointsToWrite[0].lineProtocol();
-        Assert.assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,tag1=myTag build_number=11i,build_time="));
-        Assert.assertTrue(lineProtocol.indexOf("project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i")>0);
+        assertThat(lineProtocol, startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,tag1=myTag build_number=11i,build_time="));
+        assertThat(lineProtocol, containsString("project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
     }
 
     @Test
@@ -82,6 +87,6 @@ public class CustomDataPointGeneratorTest {
         Point[] pointsToWrite = cdGen.generate();
 
         String lineProtocol = pointsToWrite[0].lineProtocol();
-        Assert.assertTrue(lineProtocol.startsWith("custom_" + customMeasurement));
+        assertThat(lineProtocol, startsWith("custom_" + customMeasurement));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -10,7 +10,6 @@ import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.influxdb.dto.Point;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -20,15 +19,18 @@ import org.mockito.stubbing.Answer;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
 /**
- * TODO: add description
- *
  * @author Eugene Schava <eschava@gmail.com>
  */
 public class PerfPublisherPointGeneratorTest {
-    public static final String JOB_NAME = "master";
-    public static final int BUILD_NUMBER = 11;
-    public static final String CUSTOM_PREFIX = "test_prefix";
+
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
 
     private Run<?,?> build;
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
@@ -62,17 +64,17 @@ public class PerfPublisherPointGeneratorTest {
     }
 
     @Test
-    public void hasReportTest() {
+    public void hasReport() {
         PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, true);
-        Assert.assertFalse(generator.hasReport());
+        assertThat(generator.hasReport(), is(false));
 
         reports.addReport(new Report());
         generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, true);
-        Assert.assertTrue(generator.hasReport());
+        assertThat(generator.hasReport(), is(true));
     }
 
     @Test
-    public void generateTest() {
+    public void generate() {
         Report report = new Report();
 
         hudson.plugins.PerfPublisher.Report.Test test = new hudson.plugins.PerfPublisher.Report.Test();
@@ -92,9 +94,9 @@ public class PerfPublisherPointGeneratorTest {
         PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, true);
         Point[] points = generator.generate();
 
-        Assert.assertTrue(points[0].lineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,number_of_executed_tests=1i"));
-        Assert.assertTrue(points[1].lineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
-        Assert.assertTrue(points[2].lineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
-        Assert.assertTrue(points[3].lineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
+        assertThat(points[0].lineProtocol(), startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,number_of_executed_tests=1i"));
+        assertThat(points[1].lineProtocol(), startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
+        assertThat(points[2].lineProtocol(), startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
+        assertThat(points[3].lineProtocol(), startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
@@ -1,26 +1,23 @@
 package jenkinsci.plugins.influxdb.generators;
 
-import static org.junit.Assert.assertEquals;
-
-import java.net.URISyntaxException;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import hudson.model.Job;
 import hudson.model.Run;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class SonarQubePointGeneratorTest {
 
-    public static final String JOB_NAME = "master";
-    public static final int BUILD_NUMBER = 11;
-    public static final String CUSTOM_PREFIX = "test_prefix";
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
 
     private Run build;
-    private Job job;
 
     private MeasurementRenderer<Run<?, ?>> measurementRenderer;
     private String sonarUrl = "http://sonar.dashboard.com";
@@ -30,7 +27,7 @@ public class SonarQubePointGeneratorTest {
     @Before
     public void before() {
         build = Mockito.mock(Run.class);
-        job = Mockito.mock(Job.class);
+        Job job = Mockito.mock(Job.class);
         measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
 
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
@@ -41,18 +38,18 @@ public class SonarQubePointGeneratorTest {
     }
 
     @Test
-    public void getSonarProjectNameFromNewSonarQubeTest() throws URISyntaxException {
+    public void getSonarProjectNameFromNewSonarQube() throws Exception {
         String name = "org.namespace:feature%2Fmy-sub-project";
         String url = sonarUrl + "/dashboard?id=" + name;
         SonarQubePointGenerator gen = new SonarQubePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, null, true);
-        assertEquals(name, gen.getSonarProjectName(url));
+        assertThat(gen.getSonarProjectName(url), is(name));
     }
 
     @Test
-    public void getSonarProjectNameTest() throws URISyntaxException {
+    public void getSonarProjectName() throws Exception {
         String name = "org.namespace:feature%2Fmy-sub-project";
         String url = sonarUrl + "/dashboard/index/" + name;
         SonarQubePointGenerator gen = new SonarQubePointGenerator(measurementRenderer, CUSTOM_PREFIX, build, currTime, null, true);
-        assertEquals(name, gen.getSonarProjectName(url));
+        assertThat(gen.getSonarProjectName(url), is(name));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRendererTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/renderer/ProjectNameRendererTest.java
@@ -2,21 +2,22 @@ package jenkinsci.plugins.influxdb.renderer;
 
 import hudson.model.Job;
 import hudson.model.Run;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
 public class ProjectNameRendererTest {
 
-    public static final String JOB_NAME = "master";
-    public static final int BUILD_NUMBER = 11;
-    public static final String CUSTOM_PREFIX = "test_prefix";
-    public static final String CUSTOM_PROJECT_NAME = "test_projectname";
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
+    private static final String CUSTOM_PROJECT_NAME = "test_projectname";
 
     private Run<?,?> build;
     private Job job;
-
 
     @Before
     public void before() {
@@ -26,35 +27,34 @@ public class ProjectNameRendererTest {
         Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
         Mockito.when(build.getParent()).thenReturn(job);
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
-
     }
 
     @Test
-    public void customProjectNameWithCustomPrefixTest() {
+    public void customProjectNameWithCustomPrefix() {
         ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, CUSTOM_PROJECT_NAME);
         String renderedProjectName = projectNameRenderer.render(build);
-        Assert.assertTrue(renderedProjectName.startsWith("test_prefix_test_projectname"));
+        assertThat(renderedProjectName, startsWith("test_prefix_test_projectname"));
     }
 
     @Test
-    public void customProjectNameWithNullPrefixTest() {
+    public void customProjectNameWithNullPrefix() {
         ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(null, CUSTOM_PROJECT_NAME);
         String renderedProjectName = projectNameRenderer.render(build);
-        Assert.assertTrue(renderedProjectName.startsWith("test_projectname"));
+        assertThat(renderedProjectName, startsWith("test_projectname"));
     }
 
     @Test
-    public void nullProjectNameWithCustomPrefixTest() {
+    public void nullProjectNameWithCustomPrefix() {
         ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
         String renderedProjectName = projectNameRenderer.render(build);
-        Assert.assertTrue(renderedProjectName.startsWith("test_prefix_master"));
+        assertThat(renderedProjectName, startsWith("test_prefix_master"));
     }
 
     @Test
-    public void nullProjectNameWithNullPrefixTest() {
+    public void nullProjectNameWithNullPrefix() {
         ProjectNameRenderer projectNameRenderer = new ProjectNameRenderer(null, null);
         String renderedProjectName = projectNameRenderer.render(build);
-        Assert.assertTrue(renderedProjectName.startsWith("master"));
+        assertThat(renderedProjectName, startsWith("master"));
     }
 
     @Test
@@ -63,10 +63,10 @@ public class ProjectNameRendererTest {
 
         Mockito.when(job.getName()).thenReturn("job 1");
         String renderedProjectName1 = projectNameRenderer.render(build);
-        Assert.assertTrue(renderedProjectName1.startsWith("job 1"));
+        assertThat(renderedProjectName1, startsWith("job 1"));
 
         Mockito.when(job.getName()).thenReturn("job 2");
         String renderedProjectName2 = projectNameRenderer.render(build);
-        Assert.assertTrue(renderedProjectName2.startsWith("job 2"));
+        assertThat(renderedProjectName2, startsWith("job 2"));
     }
 }


### PR DESCRIPTION
- no public constants
- no "Test" postfix in test methods
- use Hamcrest instead of JUnit for assertions
- use `throws Exception` on test methods for simplicity