### PR TITLE
Mark plugin configuration as compatible since version 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@ THE SOFTWARE.
         <workflow.version>2.12</workflow.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <java.level>8</java.level>
+        <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
     </properties>
 
     <licenses>


### PR DESCRIPTION
The location of `DescriptorImpl` has been moved in commit 97bebb3fa04e70c3d1fb7d0faa505f806c3cc9e3, rendering all existing configuration not readable anymore.