### PR TITLE
Fix snippet generator

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStep.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStep.java
@@ -141,6 +141,10 @@ public class InfluxDbStep extends Step {
         this.measurementName = measurementName;
     }
 
+    public boolean getReplaceDashWithUnderscore() {
+        return replaceDashWithUnderscore;
+    }
+
     @Deprecated
     @DataBoundSetter
     public void setReplaceDashWithUnderscore(boolean replaceDashWithUnderscore) {


### PR DESCRIPTION
https://github.com/jenkinsci/influxdb-plugin/pull/85 removed public getter for `replaceDashWithUnderscore`, which caused `no public field 'replaceDashWithUnderscore' (or getter method) found in class jenkinsci.plugins.influxdb.InfluxDbStep` error in the snippet generator.

Re-introduce the getter to get the snippet generator working again.