### PR TITLE
Add support for Serenity metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,11 @@ under jenkinsci.plugins.influxdb.**InfluxDbStep**.DescriptorImpl.
 - `perfpublisher_test_mnetric`
     - Test name
     - Metric name/value/relevancy
-
+- `serenity_data`
+    - Test scenario counts: total, success, pending, ignored, skipped, failure, error, compromised 
+    - Test scenario percentages: success, pending, ignored, skipped, failure, error, compromised
+    - Test scenario timings (in milliseconds): total test duration, total clock duration, min test duration, max test duration, average test duration
+    - Test scenario tags
 
 ## Configuration
 

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -7,6 +7,8 @@ import hudson.model.TaskListener;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.generators.*;
+import jenkinsci.plugins.influxdb.generators.serenity.SerenityJsonSummaryFile;
+import jenkinsci.plugins.influxdb.generators.serenity.SerenityPointGenerator;
 import jenkinsci.plugins.influxdb.models.Target;
 import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
@@ -242,6 +244,15 @@ public class InfluxDbPublicationService {
             addPoints(pointsToWrite, sonarGen, listener);
         } else {
             logger.log(Level.FINE, "Plugin skipped: SonarQube");
+        }
+
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(env.get("WORKSPACE"));
+        SerenityPointGenerator serenityGen = new SerenityPointGenerator(measurementRenderer, customPrefix, build, timestamp, listener, serenityJsonSummaryFile);
+        if (serenityGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] Serenity data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, serenityGen, listener);
+        } else {
+            logger.log(Level.FINE, "Plugin skipped: Serenity");
         }
 
         ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build, timestamp);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/ISerenityJsonSummaryFile.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/ISerenityJsonSummaryFile.java
@@ -1,0 +1,10 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface ISerenityJsonSummaryFile {
+    boolean exists();
+    Path getPath();
+    String getContents() throws IOException;
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFile.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFile.java
@@ -1,0 +1,30 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SerenityJsonSummaryFile implements ISerenityJsonSummaryFile {
+
+    private static final String SERENITY_OUTPUT_DIRECTORY = "target/site/serenity";
+    private static final String SERENITY_JSON_SUMMARY_FILE = "serenity-summary.json";
+
+    private final String workspace;
+
+    public SerenityJsonSummaryFile(String workspace) {
+        this.workspace = workspace;
+    }
+
+    public boolean exists() {
+        return Files.exists(getPath());
+    }
+
+    public Path getPath() {
+        return java.nio.file.Paths.get(workspace, SERENITY_OUTPUT_DIRECTORY, SERENITY_JSON_SUMMARY_FILE);
+    }
+
+    public String getContents() throws IOException {
+        return new String(Files.readAllBytes(getPath()), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
@@ -1,0 +1,126 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import org.influxdb.dto.Point;
+
+import java.io.IOException;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkinsci.plugins.influxdb.generators.AbstractPointGenerator;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+
+public class SerenityPointGenerator extends AbstractPointGenerator {
+
+    private static final String SERENITY_RESULTS_COUNTS_TOTAL = "serenity_results_counts_total";
+    private static final String SERENITY_RESULTS_COUNTS_SUCCESS = "serenity_results_counts_success";
+    private static final String SERENITY_RESULTS_COUNTS_PENDING = "serenity_results_counts_pending";
+    private static final String SERENITY_RESULTS_COUNTS_IGNORED = "serenity_results_counts_ignored";
+    private static final String SERENITY_RESULTS_COUNTS_SKIPPED = "serenity_results_counts_skipped";
+    private static final String SERENITY_RESULTS_COUNTS_FAILURE = "serenity_results_counts_failure";
+    private static final String SERENITY_RESULTS_COUNTS_ERROR = "serenity_results_counts_error";
+    private static final String SERENITY_RESULTS_COUNTS_COMPROMISED = "serenity_results_counts_compromised";
+
+    private static final String SERENITY_RESULTS_PERCENTAGES_SUCCESS = "serenity_results_percentages_success";
+    private static final String SERENITY_RESULTS_PERCENTAGES_PENDING = "serenity_results_percentages_pending";
+    private static final String SERENITY_RESULTS_PERCENTAGES_IGNORED = "serenity_results_percentages_ignored";
+    private static final String SERENITY_RESULTS_PERCENTAGES_SKIPPED = "serenity_results_percentages_skipped";
+    private static final String SERENITY_RESULTS_PERCENTAGES_FAILURE = "serenity_results_percentages_failure";
+    private static final String SERENITY_RESULTS_PERCENTAGES_ERROR = "serenity_results_percentages_error";
+    private static final String SERENITY_RESULTS_PERCENTAGES_COMPROMISED = "serenity_results_percentages_compromised";
+
+    private static final String SERENITY_RESULTS_TOTAL_TEST_DURATION = "serenity_results_total_test_duration";
+    private static final String SERENITY_RESULTS_TOTAL_CLOCK_DURATION = "serenity_results_total_clock_duration";
+    private static final String SERENITY_RESULTS_MIN_TEST_DURATION = "serenity_results_min_test_duration";
+    private static final String SERENITY_RESULTS_MAX_TEST_DURATION = "serenity_results_max_test_duration";
+    private static final String SERENITY_RESULTS_AVERAGE_TEST_DURATION = "serenity_results_average_test_duration";
+
+    private final Run<?, ?> build;
+    private final String customPrefix;
+    private final TaskListener listener;
+
+    // support for dependency injection
+    ISerenityJsonSummaryFile serenityJsonSummaryFile = null;
+
+    public SerenityPointGenerator(MeasurementRenderer<Run<?, ?>> projectNameRenderer, String customPrefix,
+                                  Run<?, ?> build, long timestamp, TaskListener listener,
+                                  ISerenityJsonSummaryFile serenityJsonSummaryFile) {
+        super(projectNameRenderer, timestamp);
+        this.build = build;
+        this.customPrefix = customPrefix;
+        this.listener = listener;
+        this.serenityJsonSummaryFile = serenityJsonSummaryFile;
+    }
+
+    public boolean hasReport() {
+        return (serenityJsonSummaryFile.exists());
+    }
+
+    public Point[] generate() {
+        String contents;
+        try {
+            contents = serenityJsonSummaryFile.getContents();
+        } catch (IOException e) {
+            listener.getLogger().println("Failed to read from file " + serenityJsonSummaryFile.getPath() + ", due to: " + e);
+            return null;
+        }
+
+        Point point = null;
+        JSONObject root = JSONObject.fromObject(contents);
+        JSONObject results = root.getJSONObject("results");
+        JSONObject resultsCounts = results.getJSONObject("counts");
+        JSONObject resultsPercentages = results.getJSONObject("percentages");
+        JSONArray tagTypes = root.getJSONArray("tags");
+
+        Point.Builder builder = buildPoint("serenity_data", customPrefix, build);
+
+        // include results.counts fields
+        builder
+            .addField(SERENITY_RESULTS_COUNTS_TOTAL, resultsCounts.getInt("total"))
+            .addField(SERENITY_RESULTS_COUNTS_SUCCESS, resultsCounts.getInt("success"))
+            .addField(SERENITY_RESULTS_COUNTS_PENDING, resultsCounts.getInt("pending"))
+            .addField(SERENITY_RESULTS_COUNTS_IGNORED, resultsCounts.getInt("ignored"))
+            .addField(SERENITY_RESULTS_COUNTS_SKIPPED, resultsCounts.getInt("skipped"))
+            .addField(SERENITY_RESULTS_COUNTS_FAILURE, resultsCounts.getInt("failure"))
+            .addField(SERENITY_RESULTS_COUNTS_ERROR, resultsCounts.getInt("error"))
+            .addField(SERENITY_RESULTS_COUNTS_COMPROMISED, resultsCounts.getInt("compromised"));
+
+        // include results.percentages fields
+        builder
+            .addField(SERENITY_RESULTS_PERCENTAGES_SUCCESS, resultsPercentages.getInt("success"))
+            .addField(SERENITY_RESULTS_PERCENTAGES_PENDING, resultsPercentages.getInt("pending"))
+            .addField(SERENITY_RESULTS_PERCENTAGES_IGNORED, resultsPercentages.getInt("ignored"))
+            .addField(SERENITY_RESULTS_PERCENTAGES_SKIPPED, resultsPercentages.getInt("skipped"))
+            .addField(SERENITY_RESULTS_PERCENTAGES_FAILURE, resultsPercentages.getInt("failure"))
+            .addField(SERENITY_RESULTS_PERCENTAGES_ERROR, resultsPercentages.getInt("error"))
+            .addField(SERENITY_RESULTS_PERCENTAGES_COMPROMISED, resultsPercentages.getInt("compromised"));
+
+        // include remaining results fields
+        builder
+            .addField(SERENITY_RESULTS_TOTAL_TEST_DURATION, results.getLong("totalTestDuration"))
+            .addField(SERENITY_RESULTS_TOTAL_CLOCK_DURATION, results.getLong("totalClockDuration"))
+            .addField(SERENITY_RESULTS_MIN_TEST_DURATION, results.getLong("minTestDuration"))
+            .addField(SERENITY_RESULTS_MAX_TEST_DURATION, results.getLong("maxTestDuration"))
+            .addField(SERENITY_RESULTS_AVERAGE_TEST_DURATION, results.getLong("averageTestDuration"));
+
+        // include tags fields
+        for (int iTagType = 0; iTagType < tagTypes.size(); iTagType++) {
+            JSONObject tagType = tagTypes.getJSONObject(iTagType);
+            String tagTypeType = tagType.getString("tagType");
+            JSONArray tagResults = tagType.getJSONArray("tagResults");
+            for (int iTag = 0; iTag < tagResults.size(); iTag++) {
+                JSONObject tagResult = tagResults.getJSONObject(iTag);
+                String field = "serenity_tags_" + tagTypeType + ":" + tagResult.getString("tagName");
+                builder
+                    .addField(field, tagResult.getInt("count"));
+            }
+        }
+
+        // bring it all together
+        point = builder.build();
+
+        return new Point[]{point};
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityCannedJsonSummaryFile.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityCannedJsonSummaryFile.java
@@ -1,0 +1,30 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class SerenityCannedJsonSummaryFile implements ISerenityJsonSummaryFile {
+
+    public SerenityCannedJsonSummaryFile() {}
+
+    public boolean exists() {
+        return Files.exists(getPath());
+    }
+
+    public Path getPath() {
+        try {
+            return Paths.get(ClassLoader.getSystemResource("serenity/serenity-summary.json").toURI());
+        } catch (URISyntaxException e) {
+            //
+        }
+        return null;
+    }
+
+    public String getContents() throws IOException {
+        return new String(Files.readAllBytes(getPath()), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGeneratorTest.java
@@ -1,0 +1,87 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import org.influxdb.dto.Point;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+
+import static org.junit.Assert.assertTrue;
+
+public class SerenityPointGeneratorTest {
+
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
+
+    private Run build;
+
+    private MeasurementRenderer<Run<?, ?>> measurementRenderer;
+
+    private long currTime;
+
+    String points = null;
+
+    @Before
+    public void before() {
+        build = Mockito.mock(Run.class);
+        Job job = Mockito.mock(Job.class);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
+
+        Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
+        Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+
+        currTime = System.currentTimeMillis();
+
+        SerenityCannedJsonSummaryFile serenityCannedJsonSummaryFile = new SerenityCannedJsonSummaryFile();
+        SerenityPointGenerator serenityGen = new SerenityPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+            currTime, null, serenityCannedJsonSummaryFile);
+
+        if (serenityGen.hasReport()) {
+            List<Point> pointsToWrite = new ArrayList<>();
+            pointsToWrite.addAll(Arrays.asList(serenityGen.generate()));
+            // points.fields is private so just get all fields as a single string
+            points = pointsToWrite.get(0).toString();
+        }
+    }
+
+    @Test
+    public void verifyResultsCounts() {
+        assertTrue(points.contains("serenity_results_counts_total=99"));
+        assertTrue(points.contains("serenity_results_counts_success=91"));
+        assertTrue(points.contains("serenity_results_counts_pending=8"));
+        assertTrue(points.contains("serenity_results_counts_error=0"));
+    }
+
+    @Test
+    public void verifyResultsPercentages() {
+        assertTrue(points.contains("serenity_results_percentages_success=92"));
+        assertTrue(points.contains("serenity_results_percentages_pending=8"));
+        assertTrue(points.contains("serenity_results_percentages_ignored=0"));
+    }
+
+    @Test
+    public void verifyResultsTimings() {
+        assertTrue(points.contains("serenity_results_max_test_duration=199957"));
+        assertTrue(points.contains("serenity_results_total_clock_duration=489836"));
+        assertTrue(points.contains("serenity_results_min_test_duration=1714"));
+    }
+
+    @Test
+    public void verifyTags() {
+        assertTrue(points.contains("serenity_tags_:branding=14"));
+        assertTrue(points.contains("serenity_tags_context:API=73"));
+        assertTrue(points.contains("serenity_tags_context:UI=26"));
+    }
+}

--- a/src/test/resources/serenity/serenity-summary.json
+++ b/src/test/resources/serenity/serenity-summary.json
@@ -1,0 +1,1149 @@
+{
+  "report": {
+    "title": "Serenity Summary Report",
+    "tagCategoryTitle": "Category",
+    "version": "",
+    "date": "2020-02-03T06:39:23.189"
+  },
+  "results": {
+    "counts": {
+      "total": 99,
+      "success": 91,
+      "pending": 8,
+      "ignored": 0,
+      "skipped": 0,
+      "failure": 0,
+      "error": 0,
+      "compromised": 0
+    },
+    "percentages": {
+      "success": 92,
+      "pending": 8,
+      "ignored": 0,
+      "skipped": 0,
+      "failure": 0,
+      "error": 0,
+      "compromised": 0
+    },
+    "totalTestDuration": 3275953,
+    "totalClockDuration": 489836,
+    "minTestDuration": 1714,
+    "maxTestDuration": 199957,
+    "averageTestDuration": 46140
+  },
+  "resultsByFeature": [
+    {
+      "featureName": "Authenticate user using MFA during account recovery",
+      "scenarios": [
+        {
+          "title": "Authenticate user using software MFA during account recovery",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Authenticate user using hardware MFA during account recovery",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "Authenticate user using security questions during account recovery",
+      "scenarios": [
+        {
+          "title": "New users must set up security questions",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Authenticate user using a security question during account recovery",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Authenticate user using a security question during account recovery (incorrect first answer)",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "Configure customer hardware MFA",
+      "scenarios": [
+        {
+          "title": "Enable hardware MFA for a customer that has purchased it",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Import token seed file",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Import token seed file containing an existing token",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "Configure user hardware MFA",
+      "scenarios": [
+        {
+          "title": "Enable hardware MFA by customer admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Disable hardware MFA by customer admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Enable hardware MFA by brand admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Disable hardware MFA by brand admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "First login for user with hardware MFA enabled",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Login after user hardware MFA configured",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Login with incorrect OTP code presented",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Make hardware MFA token available for reuse when MFA reset for a user",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Make hardware MFA token available for reuse when a user is deleted",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Make hardware MFA token available for reuse when MFA type changed for a user with hardware MFA enabled",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    },
+    {
+      "featureName": "Configure user software MFA",
+      "scenarios": [
+        {
+          "title": "Enable software MFA by customer admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Disable software MFA by customer admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Enable software MFA by brand admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Disable software MFA by brand admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "First login for user with software MFA enabled",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Login after user MFA configured on a user's device",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Login with incorrect OTP code presented",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "Customer management by Brand Admins",
+      "scenarios": [
+        {
+          "title": "Get customers",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Get customers using name search",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Get customer",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Create customer",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    },
+    {
+      "featureName": "Customer module licensing",
+      "scenarios": [
+        {
+          "title": "License customer for module during customer creation",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "License customer for module after customer creation",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Remove customer license for module",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    },
+    {
+      "featureName": "Handle different brands during tenant and user management",
+      "scenarios": [
+        {
+          "title": "Create BigBank user",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Delete BigBank user",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Modify BigBank user details",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Grant access to a module during BigBank user creation",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Grant access to a module after BigBank user creation",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Remove access to a module",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    },
+    {
+      "featureName": "Multi Admin approvals",
+      "scenarios": [
+        {
+          "title": "Making a change to a user results in the creation of a change request",
+          "result": "pending",
+          "outcomes": []
+        },
+        {
+          "title": "A user with a pending change request cannot be updated until request is approved/rejected",
+          "result": "pending",
+          "outcomes": [
+            {
+              "result": "pending",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "A single rejection of a change request stops it from being applied",
+          "result": "pending",
+          "outcomes": [
+            {
+              "result": "pending",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "When the number of approvals is met, the change request is applied",
+          "result": "pending",
+          "outcomes": [
+            {
+              "result": "pending",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Administrators can view all change requests that they can approve",
+          "result": "pending",
+          "outcomes": [
+            {
+              "result": "pending",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Administrators can view details for a change request that they can approve",
+          "result": "pending",
+          "outcomes": [
+            {
+              "result": "pending",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "System Branding",
+      "scenarios": [
+        {
+          "title": "The look and feel of System must be branded",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "System Pre-Session Branding",
+      "scenarios": [
+        {
+          "title": "System Pre-Session must be branded",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "Reset user hardware MFA",
+      "scenarios": [
+        {
+          "title": "Reset hardware MFA",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    },
+    {
+      "featureName": "Reset user software MFA",
+      "scenarios": [
+        {
+          "title": "Reset software MFA",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    },
+    {
+      "featureName": "Skip hardware MFA configuration",
+      "scenarios": [
+        {
+          "title": "Skip hardware MFA configuration for a new user",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "Step Up Authentication",
+      "scenarios": [
+        {
+          "title": "Step Up Authentication software MFA TOTP code validation",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Step Up Authentication hardware MFA TOTP code validation",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Step Up Authentication software MFA TOTP with incorrect OTP code presented",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Step Up Authentication hardware MFA TOTP with incorrect OTP code presented",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "featureName": "User management",
+      "scenarios": [
+        {
+          "title": "Get users",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Get user",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Fail to get user belonging to another customer",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Create user",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Fail to create user when not customer user admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Fail to create user when not brand user admin",
+          "result": "success",
+          "outcomes": [
+            {
+              "result": "success",
+              "description": "",
+              "errorMessage": ""
+            }
+          ]
+        },
+        {
+          "title": "Create user with no module access",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Delete user",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Modify user details",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Grant access to a module during user creation",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Grant access to a module after user creation",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Fail to grant access to a module during user creation when not a module admin",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Fail to grant access to a module after user creation when not a module admin",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Remove access to a module",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Make user a user admin",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Make user a module admin",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Make user no longer a user admin",
+          "result": "success",
+          "outcomes": []
+        },
+        {
+          "title": "Make user no longer a module admin",
+          "result": "success",
+          "outcomes": []
+        }
+      ]
+    }
+  ],
+  "frequentFailures": [
+  ],
+  "unstableFeatures": [
+  ],
+  "coverage": [
+    {
+      "tagTitle": "Feature",
+      "tagCoverages": [
+        {
+          "tagName": "Handle different brands during tenant and user management",
+          "testCount": 12,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 12,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "System Branding",
+          "testCount": 1,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 1,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "System Pre-Session Branding",
+          "testCount": 1,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 1,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Customer management by Brand Admins",
+          "testCount": 4,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 4,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Customer module licensing",
+          "testCount": 3,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 3,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Multi Admin approvals",
+          "testCount": 8,
+          "successRate": "0%",
+          "counts": {
+            "total": 99,
+            "success": 0,
+            "pending": 8,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 0,
+            "pending": 100,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Authenticate user using MFA during account recovery",
+          "testCount": 2,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 2,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Authenticate user using security questions during account recovery",
+          "testCount": 3,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 3,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Configure customer hardware MFA",
+          "testCount": 3,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 3,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Configure user hardware MFA",
+          "testCount": 13,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 13,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Configure user software MFA",
+          "testCount": 7,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 7,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Reset user hardware MFA",
+          "testCount": 2,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 2,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Reset user software MFA",
+          "testCount": 2,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 2,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Skip hardware MFA configuration",
+          "testCount": 1,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 1,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "Step Up Authentication",
+          "testCount": 4,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 4,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        },
+        {
+          "tagName": "User management",
+          "testCount": 33,
+          "successRate": "100%",
+          "counts": {
+            "total": 99,
+            "success": 33,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          },
+          "percentages": {
+            "success": 100,
+            "pending": 0,
+            "ignored": 0,
+            "skipped": 0,
+            "failure": 0,
+            "error": 0,
+            "compromised": 0
+          }
+        }
+      ]
+    }
+  ],
+  "tags": [
+    {
+      "tagType": "",
+      "tagResults": [
+        {
+          "tagName": "branding",
+          "count": 14
+        },
+        {
+          "tagName": "customermanagement",
+          "count": 7
+        },
+        {
+          "tagName": "multiadmin",
+          "count": 8
+        },
+        {
+          "tagName": "multifactorauthentication",
+          "count": 37
+        },
+        {
+          "tagName": "usermanagement",
+          "count": 33
+        }
+      ]
+    },
+    {
+      "tagType": "context",
+      "tagResults": [
+        {
+          "tagName": "API",
+          "count": 73
+        },
+        {
+          "tagName": "UI",
+          "count": 26
+        }
+      ]
+    }
+  ]
+}
+
+
+


### PR DESCRIPTION
**Summary of this PR**
Collects data from a Serenity report and sends the metrics to an InfluxDB instance.

**How should this be manually tested?**
Run Serenity in a Jenkins job (using either Maven or Gradle) with the JSON summary report enabled.  The InfluxDB plugin for Jenkins will then extract the data from the report and send the metrics to the configured InfluxDB instance.

**Side effects**
None,

**Documentation**
README.md has been updated.

**Relevant tickets**
JENKINS-60687