### PR TITLE
JENKINS-61305 - Fix freestyle jobs using first configured targets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,30 +168,6 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-core</artifactId>
-            <version>2.0.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.0</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -4,7 +4,6 @@ import hudson.EnvVars;
 import hudson.ProxyConfiguration;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.generators.*;
 import jenkinsci.plugins.influxdb.generators.serenity.SerenityJsonSummaryFile;

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -59,6 +59,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
         return target;
     }
 
+    @DataBoundSetter
     public void setSelectedTarget(String target) {
         Objects.requireNonNull(target);
         this.selectedTarget = target;

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -2,28 +2,30 @@ package jenkinsci.plugins.influxdb;
 
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
+import jenkinsci.plugins.influxdb.models.Target;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.Collections;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "javax.activation.*"})
-@PrepareForTest(Jenkins.class)
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 public class InfluxDbPublisherTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -37,7 +39,7 @@ public class InfluxDbPublisherTest {
     private TaskListener listener;
 
     @Test
-    public void emptyTarget() throws Exception {
+    public void testEmptyTargetShouldThrowException() throws Exception {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Target was null!");
 
@@ -45,13 +47,34 @@ public class InfluxDbPublisherTest {
         Jenkins jenkinsMock = Mockito.mock(Jenkins.class);
         Mockito.when(descriptorMock.getTargets()).thenReturn(Collections.emptyList());
         Mockito.when(jenkinsMock.getDescriptorByType(InfluxDbPublisher.DescriptorImpl.class)).thenReturn(descriptorMock);
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
 
         try {
             new InfluxDbPublisher("").perform(build, workspace, launcher, listener);
         } catch (NullPointerException e) {
             Assert.fail("NullPointerException raised");
         }
+    }
+
+    @Test
+    @Issue("JENKINS-61305")
+    public void testConfigRoundTripShouldPreserveSelectedTarget() throws Exception {
+        InfluxDbGlobalConfig globalConfig = InfluxDbGlobalConfig.getInstance();
+        Target target1 = new Target();
+        target1.setDescription("Target1");
+        Target target2 = new Target();
+        target2.setDescription("Target2");
+        globalConfig.addTarget(target1);
+        globalConfig.addTarget(target2);
+
+        InfluxDbPublisher before = new InfluxDbPublisher("Target2");
+        assertThat(before.getSelectedTarget(), is("Target2"));
+        assertThat(before.getTarget(), is(target2));
+
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getPublishersList().add(before);
+        j.submit(j.createWebClient().getPage(project,"configure").getFormByName("config"));
+
+        InfluxDbPublisher after = project.getPublishersList().get(InfluxDbPublisher.class);
+        j.assertEqualBeans(before, after, "selectedTarget");
     }
 }


### PR DESCRIPTION
Release 2.0 removed `@DataboundSetter` from `InfluxDbPublisher.setSelectedTarget()`. Re-adds that and implements corresponding unit test