### PR TITLE
Update for SonarQube 8.1

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -22,12 +22,11 @@ import org.influxdb.dto.Point;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class InfluxDbPublicationService {
 
@@ -305,7 +304,7 @@ public class InfluxDbPublicationService {
 
     private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {
         try {
-            pointsToWrite.addAll(Arrays.asList(generator.generate()));
+            pointsToWrite.addAll(Arrays.stream(generator.generate()).filter(Objects::nonNull).collect(Collectors.toList()));
         } catch (Exception e) {
             listener.getLogger().println("[InfluxDB Plugin] Failed to collect data. Ignoring Exception:" + e);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -46,7 +46,8 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 
     private static final String SONAR_ISSUES_BASE_URL = "/api/issues/search?ps=500&projectKeys=";
 
-    private static final String SONAR_METRICS_BASE_URL = "/api/measures/component?componentKey=";
+    // SonarQube 5.4+ expects componentKey=, SonarQube 8.1 expects component=, we can make both of them happy
+    private static final String SONAR_METRICS_BASE_URL = "/api/measures/component?componentKey=%s&component=%s";
     private static final String SONAR_METRICS_BASE_METRIC = "&metricKeys=";
     private static final OkHttpClient httpClient = new OkHttpClient();
 
@@ -108,7 +109,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                 }
             }
             sonarIssuesUrl = sonarServer + SONAR_ISSUES_BASE_URL + sonarProjectName + "&resolved=false&severities=";
-            sonarMetricsUrl = sonarServer + SONAR_METRICS_BASE_URL + sonarProjectName;
+            sonarMetricsUrl = sonarServer + String.format(SONAR_METRICS_BASE_URL, sonarProjectName, sonarProjectName);
         } catch (URISyntaxException e) {
             //
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -147,7 +147,9 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                     .addField(SONARQUBE_COMPLEXITY, getSonarMetric(sonarMetricsUrl, SONARQUBE_COMPLEXITY))
                     .build();
         } catch (IOException e) {
-            // handle
+            String logMessage = "[InfluxDB Plugin] INFO: IOException while fetching SonarQube metrics: " + e.getMessage();
+            listener.getLogger().println(logMessage);
+            e.printStackTrace(listener.getLogger());
         }
         return new Point[] { point };
     }


### PR DESCRIPTION
* Make the SonarQube metrics work for SonarQube 8.1.
* Ignore Points from failing Generators.