### PR TITLE
Add JUnit reporting to influxdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,24 @@ Tags specific for this measurement:
 | commit_messages | string | Comma-separated list of commit messages | |
 | culprits | string | Comma-separated list of commit authors | |
 
+#### `junit_data` (since 2.3)
+
+| Metric | Type | Description | Introduced in |
+| --- | --- | --- | --- |
+| suite_name | string | Testsuite name | |
+| test_name | string | Test name | |
+| test_status | string | PASSED, SKIPPED, FAILED, FIXED, REGRESSION | |
+| test_status_ordinal | integer | 0-4 in order of test_status | |
+| test_duration | float | test duration in seconds | |
+
+Tags specific for this measurement:
+
+| Tag | Description | Introduced in |
+| --- | --- | --- |
+| suite_name | Testsuite name | |
+| test_name | Test name | |
+| test_status | Test result | |
+
 #### `sonarqube_data` (since 1.11)
 
 | Metric | Type | Description | Introduced in |

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.2</version>
+            <version>1.10</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -235,6 +235,14 @@ public class InfluxDbPublicationService {
             logger.log(Level.FINE, "Plugin skipped: Performance");
         }
 
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix, env);
+        if (junitGen.hasReport()) {
+            listener.getLogger().println("[InfluxDB Plugin] JUnit data found. Writing to InfluxDB...");
+            addPoints(pointsToWrite, junitGen, listener);
+        } else {
+            logger.log(Level.FINE, "Plugin skipped: JUnit");
+        }
+
         SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix);
         if (sonarGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
@@ -1,0 +1,86 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.test.AbstractTestResultAction;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import org.influxdb.dto.Point;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JUnitPointGenerator extends AbstractPointGenerator{
+
+    private static final String JUNIT_SUITE_NAME = "suite_name";
+    private static final String JUNIT_TEST_NAME = "test_name";
+    private static final String JUNIT_TEST_STATUS = "test_status";
+    private static final String JUNIT_TEST_STATUS_ORDINAL = "test_status_ordinal";
+    private static final String JUNIT_DURATION = "test_duration";
+
+    private final String customPrefix;
+    private final TaskListener listener;
+
+    private final EnvVars env;
+
+    public JUnitPointGenerator(Run<?, ?> build, TaskListener listener,
+                               MeasurementRenderer<Run<?, ?>> projectNameRenderer,
+                               long timestamp, String jenkinsEnvParameterTag,
+                               String customPrefix, EnvVars env) {
+        super(build, listener, projectNameRenderer, timestamp, jenkinsEnvParameterTag);
+        this.customPrefix = customPrefix;
+        this.listener = listener;
+        this.env = env;
+    }
+
+    /**
+     * @return true, if environment variable LOG_JUNIT_RESULTS is set to true and JUnit Reports exist
+     */
+    @Override
+    public boolean hasReport() {
+        return Boolean.parseBoolean(env.getOrDefault("LOG_JUNIT_RESULTS", "false")) && hasTestResults(build);
+    }
+
+    @Override
+    public Point[] generate() {
+
+        List<Point> points = new ArrayList<>();
+
+        // iterate each caseResult to get suiteName, testName and testStatus
+        List<CaseResult> allTestResults = getAllTestResults(build);
+
+        for (CaseResult caseResult : allTestResults) {
+            Point point = buildPoint("junit_data", customPrefix, build)
+                    .addField(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
+                    .addField(JUNIT_TEST_NAME, caseResult.getDisplayName())
+                    .addField(JUNIT_TEST_STATUS, caseResult.getStatus().toString())
+                    .addField(JUNIT_TEST_STATUS_ORDINAL, caseResult.getStatus().ordinal())
+                    .addField(JUNIT_DURATION, caseResult.getDuration())
+                    .tag(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
+                    .tag(JUNIT_TEST_NAME, caseResult.getDisplayName())
+                    .tag(JUNIT_TEST_STATUS, caseResult.getStatus().toString())
+                    .build();
+            points.add(point);
+        }
+
+        return points.toArray(new Point[points.size()]);
+    }
+
+    private List<CaseResult> getAllTestResults(Run<?, ?> build) {
+        //get tests from build
+        AbstractTestResultAction testResultAction = build.getAction(AbstractTestResultAction.class);
+
+        // create a list that contains all tests
+        List<CaseResult> allTestResults = new ArrayList<>();
+        allTestResults.addAll(testResultAction.getFailedTests());
+        allTestResults.addAll(testResultAction.getSkippedTests());
+        allTestResults.addAll(testResultAction.getPassedTests());
+
+        return allTestResults;
+    }
+
+    private boolean hasTestResults(Run<?, ?> build) {
+        return build.getAction(AbstractTestResultAction.class) != null;
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JUnitPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JUnitPointGeneratorTest.java
@@ -1,0 +1,99 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import hudson.EnvVars;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.test.AbstractTestResultAction;
+import jenkinsci.plugins.influxdb.renderer.MeasurementRenderer;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JUnitPointGeneratorTest {
+
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
+
+    private Run build;
+    private TaskListener listener;
+    private MeasurementRenderer<Run<?, ?>> measurementRenderer;
+
+    private long currTime;
+
+    @Before
+    public void before() {
+        build = Mockito.mock(Run.class);
+        Job job = Mockito.mock(Job.class);
+        listener = Mockito.mock(TaskListener.class);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
+
+        Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
+        Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+
+        currTime = System.currentTimeMillis();
+    }
+
+    @Test
+    public void hasReport_tests_exist_and_flag_is_true() {
+        EnvVars envVars = new EnvVars();
+        envVars.put("LOG_JUNIT_RESULTS", "true");
+
+        Mockito.when(build.getAction(AbstractTestResultAction.class)).thenReturn(Mockito.mock(AbstractTestResultAction.class));
+
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars);
+        Assert.assertEquals(true, junitGen.hasReport());
+    }
+
+    @Test
+    public void hasReport_tests_exist_and_flag_is_false() {
+        EnvVars envVars = new EnvVars();
+        envVars.put("LOG_JUNIT_RESULTS", "false");
+
+        Mockito.when(build.getAction(AbstractTestResultAction.class)).thenReturn(Mockito.mock(AbstractTestResultAction.class));
+
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars);
+        Assert.assertEquals(false, junitGen.hasReport());
+    }
+
+    @Test
+    public void hasReport_tests_exist_and_flag_is_missing() {
+        EnvVars envVars = new EnvVars();
+
+        Mockito.when(build.getAction(AbstractTestResultAction.class)).thenReturn(Mockito.mock(AbstractTestResultAction.class));
+
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars);
+        Assert.assertEquals(false, junitGen.hasReport());
+    }
+
+    @Test
+    public void hasReport_no_tests_and_flag_is_true() {
+        EnvVars envVars = new EnvVars();
+        envVars.put("LOG_JUNIT_RESULTS", "true");
+
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars);
+        Assert.assertEquals(false, junitGen.hasReport());
+    }
+
+    @Test
+    public void hasReport_no_tests_and_flag_is_false() {
+        EnvVars envVars = new EnvVars();
+        envVars.put("LOG_JUNIT_RESULTS", "false");
+
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars);
+        Assert.assertEquals(false, junitGen.hasReport());
+    }
+
+    @Test
+    public void hasReport_no_tests_and_flag_is_missing() {
+        EnvVars envVars = new EnvVars();
+
+        JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars);
+        Assert.assertEquals(false, junitGen.hasReport());
+    }
+}


### PR DESCRIPTION
Hello,

I thought it might be useful to also have junit_data available in InfluxDB as to checking passrate of tests, seeing which testsuites have the most failures and so on. I had to update the junit dependency to 1.10 to get all tests (passed, failed and skipped).

 I've added a check that requires the environment variable **_LOG_JUNIT_RESULTS_** to be **_true_** in order to log the results to InfluxDB. 

I must admit that I'm not quite sure if adding metrics as fields and tags is necessary or even considered to be correct.
