### PR TITLE
Support of build_branch_name, build_causer and alert_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ All measurements share the following tags:
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
 | build_agent_name | string | Name of the executor node | 1.15 |
+| build_branch_name | string | Branch name of multibranch pipeline | |
+| buid_causer | string | Short description of build causer| |
 | build_exec_time | integer | Start time of the build | 1.17 |
 | build_measured_time | integer | Time when InfluxDB plugin is called | 1.17 |
 | build_result | string | SUCCESS, FAILURE, NOT BUILT, UNSTABLE, ABORTED, ?  | 1.10 |
@@ -298,6 +300,7 @@ Tags specific for this measurement:
 
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
+| alert_status | string | State of the Quality Gate | |
 | blocker_issues | float | Total amount of blocker issues | |
 | branch_coverage | float | Branch coverage | 2.2 |
 | bugs | float | Total amount of bugs | 2.2 |

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -39,6 +39,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String SONARQUBE_BRANCH_COVERAGE = "branch_coverage";
     private static final String SONARQUBE_LINE_COVERAGE = "line_coverage";
     private static final String SONARQUBE_LINES_TO_COVER = "lines_to_cover";
+    private static final String SONARQUBE_ALERT_STATUS = "alert_status"; //Quality Gate Status 
     private static final String SONARQUBE_DUPLICATED_LINES_DENSITY = "duplicated_lines_density";
     private static final String SONARQUBE_TECHNICAL_DEBT = "sqale_index";
 
@@ -147,6 +148,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                     .addField(SONARQUBE_LINES_TO_COVER, getSonarMetric(sonarMetricsUrl, SONARQUBE_LINES_TO_COVER))
                     .addField(SONARQUBE_DUPLICATED_LINES_DENSITY, getSonarMetric(sonarMetricsUrl, SONARQUBE_DUPLICATED_LINES_DENSITY))
                     .addField(SONARQUBE_COMPLEXITY, getSonarMetric(sonarMetricsUrl, SONARQUBE_COMPLEXITY))
+                    .addField(SONARQUBE_ALERT_STATUS, getSonarMetricStr(sonarMetricsUrl, SONARQUBE_ALERT_STATUS))
                     .addField(SONARQUBE_TECHNICAL_DEBT, getSonarMetric(sonarMetricsUrl, SONARQUBE_TECHNICAL_DEBT))
                     .build();
         } catch (IOException e) {
@@ -204,15 +206,31 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         return projectUrl.length > 1 ? projectUrl[projectUrl.length - 1] : "";
     }
 
+    public String getSonarMetricStr(String url, String metric) throws IOException {
+        return getSonarMetricValue(url, metric);
+    }
+
     public Float getSonarMetric(String url, String metric) throws IOException {
         Float value = null;
+        
+        try {
+            value = Float.parseFloat(getSonarMetricValue(url, metric));
+        } catch (NumberFormatException exp) {}
+
+        return value;
+    }
+
+    private String getSonarMetricValue(String url, String metric) throws IOException {
+
+        String value = "";
         String output = getResult(url + SONAR_METRICS_BASE_METRIC + metric);
         JSONObject metricsObjects = JSONObject.fromObject(output);
         try {
             JSONArray array = metricsObjects.getJSONObject("component").getJSONArray("measures");
             JSONObject metricsObject = array.getJSONObject(0);
-            value = Float.parseFloat(metricsObject.getString("value"));
-        } catch (NumberFormatException | IndexOutOfBoundsException exp) {}
+            value = metricsObject.getString("value").toString();
+        } catch (IndexOutOfBoundsException exp) {}
+
         return value;
     }
 

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGeneratorTest.java
@@ -71,6 +71,7 @@ public class JenkinsBasePointGeneratorTest {
         Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_FIELD)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_FIELD);
         Mockito.when(mockedEnvVars.get(JENKINS_ENV_VALUE_TAG)).thenReturn(JENKINS_ENV_RESOLVED_VALUE_TAG);
         Mockito.when(mockedEnvVars.get("NODE_NAME")).thenReturn(null);
+        Mockito.when(mockedEnvVars.get("BRANCH_NAME")).thenReturn(null);
 
         currTime = System.currentTimeMillis();
     }
@@ -97,6 +98,30 @@ public class JenkinsBasePointGeneratorTest {
         assertThat(lineProtocol, containsString("build_agent_name=\"\""));
         assertThat(lineProtocol, containsString("project_path=\"folder/master\""));
     }
+
+    @Test
+    public void branch_present() {
+        Mockito.when(build.getExecutor()).thenReturn(executor);
+        Mockito.when(mockedEnvVars.get("BRANCH_NAME")).thenReturn("develop");
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, StringUtils.EMPTY, CUSTOM_PREFIX, MEASUREMENT_NAME, mockedEnvVars);
+        Point[] points = generator.generate();
+        String lineProtocol = points[0].lineProtocol();
+
+        assertThat(lineProtocol, containsString("build_branch_name=\"develop\""));
+        assertThat(lineProtocol, containsString("project_path=\"folder/master\""));
+    }
+
+    @Test
+    public void brach_not_present() {
+        Mockito.when(build.getExecutor()).thenReturn(null);
+        JenkinsBasePointGenerator generator = new JenkinsBasePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, StringUtils.EMPTY, CUSTOM_PREFIX, MEASUREMENT_NAME, mockedEnvVars);
+        Point[] points = generator.generate();
+        String lineProtocol = points[0].lineProtocol();
+
+        assertThat(lineProtocol, containsString("build_branch_name=\"\""));
+        assertThat(lineProtocol, containsString("project_path=\"folder/master\""));
+    }
+
 
     @Test
     public void scheduled_and_start_and_end_time_present() {


### PR DESCRIPTION
With this merge request following will also publish to influxdb:

* `build_branch_name`: Branch name of multi-branch pipeline. It uses `env.BRANCH_NAME` variable.
* `build_causer`: Short description of build causer. So, we can distinct between the build causes. Examples:
    - Started by Volkan Kumbasar
    - Started by timer
    - Started by upstream project "dummy" build number 34
* `alert_status`: [Quality Gate Status](https://docs.sonarqube.org/latest/user-guide/metric-definitions/#header-5)

