### PR TITLE
add technical debt ratio metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Tags specific for this measurement:
 | minor_issues | float | Total amount of minor issues | |
 | vulnerabilities | float | Total amount of vulnerabilities | 2.2 |
 | sqale_index | float | Technical Debt |  |
+| sqale_debt_ratio | float | Technical Debt Ratio |  |
 
 
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -42,7 +42,8 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String SONARQUBE_ALERT_STATUS = "alert_status"; //Quality Gate Status 
     private static final String SONARQUBE_DUPLICATED_LINES_DENSITY = "duplicated_lines_density";
     private static final String SONARQUBE_TECHNICAL_DEBT = "sqale_index";
-
+    private static final String SONARQUBE_TECHNICAL_DEBT_RATIO = "sqale_debt_ratio";
+    
     private static final String URL_PATTERN_IN_LOGS = ".*" + Pattern.quote("ANALYSIS SUCCESSFUL, you can browse ")
             + "(.*)";
 
@@ -150,6 +151,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                     .addField(SONARQUBE_COMPLEXITY, getSonarMetric(sonarMetricsUrl, SONARQUBE_COMPLEXITY))
                     .addField(SONARQUBE_ALERT_STATUS, getSonarMetricStr(sonarMetricsUrl, SONARQUBE_ALERT_STATUS))
                     .addField(SONARQUBE_TECHNICAL_DEBT, getSonarMetric(sonarMetricsUrl, SONARQUBE_TECHNICAL_DEBT))
+                    .addField(SONARQUBE_TECHNICAL_DEBT_RATIO, getSonarMetric(sonarMetricsUrl, SONARQUBE_TECHNICAL_DEBT_RATIO))
                     .build();
         } catch (IOException e) {
             String logMessage = "[InfluxDB Plugin] INFO: IOException while fetching SonarQube metrics: " + e.getMessage();


### PR DESCRIPTION
Enhance `sonarqube` data with the [technical dept ratio](https://docs.sonarqube.org/latest/user-guide/metric-definitions/#header-5) metric.