### PR TITLE
support env variable configuration in global listener [JENKINS-62753]

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Select the InfluxDB target you wish to publish the data to.
 ![](doc/img/select-influxdb-target.png)
 
 From the "Advanced" tab you can choose to set a custom prefix for your `project_name` field,
-a custom project name to be used instead of the default job name and custom fields and tags
-for your all your metrics.
+a custom project name to be used instead of the default job name, custom fields for your
+`jenkins_data` metric, and custom tags for your all your metrics.
 
 ![](doc/img/advanced-options.png)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ under jenkinsci.plugins.influxdb.**InfluxDbStep**.DescriptorImpl.
 
 ## Configuration
 
+### Configuration as Code
+
+To configure InfluxDB plugin in Jenkins add the following to `jenkins.yaml`:
+
+```yaml
+unclassified:
+  influxDbGlobalConfig:
+    targets:
+    - database: "some_database"
+      description: "some description"
+      exposeExceptions: true
+      globalListener: true
+      globalListenerFilter: "some filter"
+      jobScheduledTimeAsPointsTimestamp: true
+      password: "some password"
+      retentionPolicy: "some_policy"
+      url: "http://some/url"
+      username: "some username"
+      usingJenkinsProxy: true
+```
+
 ### Via Jenkins UI
 
 Create a database in InfluxDB and a user with access rights. In Jenkins,
@@ -91,6 +112,19 @@ influxdb.save()
 
 ## Usage
 
+### Global Listener
+
+When `globalListener` is set to `true` for a target in which no results were published during the build, it will automatically publish the result for this target when the build is completed.
+
+To configure the global listener, you can use environment variables prefixed with `INFLUXDB_PLUGIN`. The following variables are supported and all correspond to an `influxDbPublisher` optional parameter.
+
+- `INFLUXDB_PLUGIN_CUSTOM_PROJECT_NAME` -> `customProjectName`
+- `INFLUXDB_PLUGIN_CUSTOM_PREFIX` -> `customPrefix`
+- `INFLUXDB_PLUGIN_CUSTOM_FIELDS` -> `jenkinsEnvParameterField`
+- `INFLUXDB_PLUGIN_CUSTOM_TAGS` -> `jenkinsEnvParameterTag`
+
+**_NOTE:_** The environment variables must be set on the final build object. If you are creating or updating these variables in a pipeline, you should make sure they are exported with an [EnvironmentContributingAction](https://javadoc.jenkins.io/hudson/model/EnvironmentContributingAction.html).
+
 ### Freestyle Jobs
 
 Select the InfluxDB target you wish to publish the data to.
@@ -99,7 +133,7 @@ Select the InfluxDB target you wish to publish the data to.
 
 From the "Advanced" tab you can choose to set a custom prefix for your `project_name` field,
 a custom project name to be used instead of the default job name and custom fields and tags
-for your `jenkins_data` metric.
+for your all your metrics.
 
 ![](doc/img/advanced-options.png)
 
@@ -107,7 +141,7 @@ for your `jenkins_data` metric.
 
 The plugin can be used by calling either the `influxDbPublisher()` or the `step()` function.
 
-The `influxDbPublisher()` function is only supported from version 1.21 onwards.
+**_NOTE:_** The `influxDbPublisher()` function is only supported from version 1.21 onwards.
 
 **Pipeline syntax**
 
@@ -131,7 +165,7 @@ Optional parameters
 - `customDataMap` (Map) - custom fields in custom measurements
 - `customDataMapTags` (Map) - custom tags in custom measurements
 - `jenkinsEnvParameterField` (String) - custom fields in "jenkins_data" measurement (newline-separated KEY=VALUE pairs)
-- `jenkinsEnvParameterTag` (String) - custom tags in "jenkins_data" measurement (newline-separated KEY=VALUE pairs)
+- `jenkinsEnvParameterTag` (String) - custom tags in all measurements (newline-separated KEY=VALUE pairs)
 - `measurementName` (String) - custom measurement name (replaces default "jenkins_data" and "jenkins_custom_data")
 
 All `customData*` parameters contain custom data generated during the

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -133,7 +133,7 @@ public class InfluxDbPublicationService {
     private final String jenkinsEnvParameterField;
 
     /**
-     * Jenkins parameter(s) which will be added as tag set to  measurement 'jenkins_data'.
+     * Jenkins parameter(s) which will be added as tag set to all measurements.
      * If parameter value has a $-prefix, it will be resolved from current Jenkins job environment properties.
      */
     private final String jenkinsEnvParameterTag;

--- a/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 @Extension
 public class GlobalRunListener extends RunListener<Run<?, ?>> {
 
+    private static final String VARIABLE_PREFIX = "INFLUXDB_PLUGIN_";
+
     @Override
     public void onCompleted(Run<?, ?> build, @Nonnull TaskListener listener) {
         // Gets the full path of the build's project
@@ -42,20 +44,6 @@ public class GlobalRunListener extends RunListener<Run<?, ?>> {
         }
         // If some targets are selected
         if (!selectedTargets.isEmpty()) {
-            // Creates the publication service
-            InfluxDbPublicationService publicationService = new InfluxDbPublicationService(
-                    selectedTargets,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    System.currentTimeMillis() * 1000000,
-                    null,
-                    null,
-                    "jenkins_data"
-            );
 
             EnvVars env;
             try {
@@ -63,6 +51,21 @@ public class GlobalRunListener extends RunListener<Run<?, ?>> {
             } catch (IOException | InterruptedException e) {
                 env = new EnvVars();
             }
+
+            // Creates the publication service
+            InfluxDbPublicationService publicationService = new InfluxDbPublicationService(
+                    selectedTargets,
+                    env.get(VARIABLE_PREFIX + "CUSTOM_PROJECT_NAME"),
+                    env.get(VARIABLE_PREFIX + "CUSTOM_PREFIX"),
+                    null,
+                    null,
+                    null,
+                    null,
+                    System.currentTimeMillis() * 1000000,
+                    env.expand(env.get(VARIABLE_PREFIX + "CUSTOM_FIELDS")),
+                    env.expand(env.get(VARIABLE_PREFIX + "CUSTOM_TAGS")),
+                    "jenkins_data"
+            );
 
             // Publication
             publicationService.perform(build, listener, env);

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jenkinsEnvParameterTag.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/help-jenkinsEnvParameterTag.html
@@ -1,4 +1,4 @@
-Custom tag set that will be added to the default measurement 'jenkins_data', configured as key-value pairs (one per line, in Java Properties file format).
+Custom tag set that will be added to all measurements, configured as key-value pairs (one per line, in Java Properties file format).
 <p>Current build parameters and/or environment variables can be used in the form of ${PARAM}</p>
 <ul>
     <li>KEY=${PARAM}</li>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbStep/help-jenkinsEnvParameterTag.html
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbStep/help-jenkinsEnvParameterTag.html
@@ -1,4 +1,4 @@
-Custom tag set that will be added to the default measurement 'jenkins_data', configured as key-value pairs (one per line, in Java Properties file format).
+Custom tag set that will be added to all measurements, configured as key-value pairs (one per line, in Java Properties file format).
 <p>Current build parameters and/or environment variables can be used in the form of ${PARAM}</p>
 <ul>
     <li>KEY=${PARAM}</li>


### PR DESCRIPTION
Fix: https://issues.jenkins-ci.org/browse/JENKINS-62753


### Example Pipeline 

This is the pipeline I used to test

```
@Library('jenkins-pipeline-library@test-influx') _

import com.example.action.PublishEnvVarAction

pipeline {
  options {
    timestamps()
    skipDefaultCheckout()
  }
  
  agent { label "master" as String }

  stages {
    stage ("Test") {
      steps {
        script {
          publishEnv([
            "INFLUXDB_PLUGIN_CUSTOM_TAGS": 'my_tag=${TEST_REPLACE}\nmultiline=works', 
            "TEST_REPLACE": "foo",
            "INFLUXDB_PLUGIN_CUSTOM_FIELDS": 'my_field=1',
            "INFLUXDB_PLUGIN_CUSTOM_PROJECT_NAME": "custom-test-project",
            "INFLUXDB_PLUGIN_CUSTOM_PREFIX": "custom/prefix"
          ])
        }
      }
    }
  }
}
```

Note that `publishEnv` is defined in a shared library

File: `vars/publishEnv.groovy`
```groovy
package com.example

import com.example.action.PublishEnvVarAction

def call(Map config) {
     currentBuild.getRawBuild().addAction(new PublishEnvVarAction(config.collectEntries{ k, v -> [(k.toString()) : v.toString()] }))
}
```

File: `scr/com/example/action/PublishEnvVarAction.groovy`
```groovy
package com.example.action;

import hudson.EnvVars;
import hudson.model.Run;
import hudson.model.EnvironmentContributingAction;
import hudson.model.InvisibleAction;

public class PublishEnvVarAction extends InvisibleAction implements EnvironmentContributingAction {

    private final Map<String, String> envOverrides;

    public PublishEnvVarAction(final Map<String, String> env) {
        this.envOverrides = env;
    }

    @NonCPS
    @Override
    public void buildEnvironment(Run<?, ?> run, EnvVars env) {
        if (env != null && envOverrides != null){
            env.putAllNonNull(envOverrides);
        }
    }
}
```

The class `PublishEnvVarAction` will need to be whitelisted for serialization with `-Dhudson.remoting.ClassFilter=com.example.action.PublishEnvVarAction` or you will get an error like `Refusing to marshal com.example.action.PublishEnvVarAction for security reasons; see https://jenkins.io/redirect/class-filter/`

#### Result

I can see the 2 tags `multiline=works` and `my_tag=foo` expanded correctly with multiline working.
The custom field `my_field="1"` is present.
Both `prefix` and `project_name` values are the proper one.

```
jenkins_data,
build_result=SUCCESS,multiline=works,my_tag=foo,prefix=custom/prefix,project_name=custom/prefix_custom-test-project,project_path=agaudreault/tests/influx-db 
build_agent_name="",build_scheduled_time=1598555993110i,project_build_health=80i,project_path="agaudreault/tests/influx-db",time_in_queue=15i,build_exec_time=1598555993142i,build_result="SUCCESS",last_stable_build=4i,my_field="1",project_name="custom/prefix_custom-test-project",build_causer="Started by user Alexandre Gaudreault",build_measured_time=1598556002618i,build_number=4i,build_status_message="stable",last_successful_build=4i,build_branch_name="",build_result_ordinal=0i,build_successful=true,build_time=9409i
1598556002618000000
```

### TODOs

- [x] Test it