### PR TITLE
Wait for sonarqube's quality gate

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -39,36 +39,44 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String SONARQUBE_BRANCH_COVERAGE = "branch_coverage";
     private static final String SONARQUBE_LINE_COVERAGE = "line_coverage";
     private static final String SONARQUBE_LINES_TO_COVER = "lines_to_cover";
-    private static final String SONARQUBE_ALERT_STATUS = "alert_status"; //Quality Gate Status
+    private static final String SONARQUBE_ALERT_STATUS = "alert_status"; // Quality Gate Status
     private static final String SONARQUBE_DUPLICATED_LINES_DENSITY = "duplicated_lines_density";
     private static final String SONARQUBE_TECHNICAL_DEBT = "sqale_index";
     private static final String SONARQUBE_TECHNICAL_DEBT_RATIO = "sqale_debt_ratio";
 
+    private final short DEFAULT_MAX_RETRY_COUNT = 10;
+    private final int DEFAULT_RETRY_SLEEP = 5000;
+
     private static final String URL_PATTERN_IN_LOGS = ".*" + Pattern.quote("ANALYSIS SUCCESSFUL, you can browse ")
+            + "(.*)";
+    private static final String TASK_ID_PATTERN_IN_LOGS = ".*" + Pattern.quote("More about the report processing at ")
             + "(.*)";
 
     private static final String SONAR_ISSUES_BASE_URL = "/api/issues/search?ps=500&projectKeys=";
 
-    // SonarQube 5.4+ expects componentKey=, SonarQube 8.1 expects component=, we can make both of them happy
+    // SonarQube 5.4+ expects componentKey=, SonarQube 8.1 expects component=, we
+    // can make both of them happy
     private static final String SONAR_METRICS_BASE_URL = "/api/measures/component?componentKey=%s&component=%s";
     private static final String SONAR_METRICS_BASE_METRIC = "&metricKeys=";
     private static final OkHttpClient httpClient = new OkHttpClient();
 
     private String sonarIssuesUrl;
     private String sonarMetricsUrl;
+    private String sonarBuildTaskIdUrl = null;
 
     private final String customPrefix;
     private final TaskListener listener;
 
     private String sonarBuildLink = null;
+    
+
     private String token = null;
 
     private EnvVars env = null;
 
     public SonarQubePointGenerator(Run<?, ?> build, TaskListener listener,
-                                   MeasurementRenderer<Run<?, ?>> projectNameRenderer,
-                                   long timestamp, String jenkinsEnvParameterTag,
-                                   String customPrefix) {
+            MeasurementRenderer<Run<?, ?>> projectNameRenderer, long timestamp, String jenkinsEnvParameterTag,
+            String customPrefix) {
         super(build, listener, projectNameRenderer, timestamp, jenkinsEnvParameterTag);
         this.customPrefix = customPrefix;
         this.listener = listener;
@@ -76,17 +84,69 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 
     public boolean hasReport() {
         try {
-            sonarBuildLink = getSonarProjectURLFromBuildLogs(build);
+
+            String[] result = getSonarProjectURLFromBuildLogs(build);
+
+            sonarBuildLink = result[0];
+            sonarBuildTaskIdUrl = result[1];
+
             return !StringUtils.isEmpty(sonarBuildLink);
-        } catch (IOException e) {
-            //
-        }
+        } catch (IOException | IndexOutOfBoundsException e) {}
 
         return false;
     }
 
     public void setEnv(EnvVars env) {
         this.env = env;
+    }
+
+
+    private void waitForQualityGate() throws IOException {
+
+        String status = null;
+        String output = null;
+        String logMessage = null;
+
+        int count = 0;
+
+        int MAX_RETRY_COUNT = DEFAULT_MAX_RETRY_COUNT;
+
+        String max_retry = this.env.get("SONAR_TASK_MAX_RETRY_COUNT");
+
+        if (max_retry != null && !max_retry.isEmpty()) {
+            try {
+                MAX_RETRY_COUNT = Integer.parseInt(max_retry);
+            } catch(NumberFormatException e) {
+                MAX_RETRY_COUNT = DEFAULT_MAX_RETRY_COUNT;
+            }
+        }
+
+        do {
+            try {
+                Thread.sleep(DEFAULT_RETRY_SLEEP);
+            } catch(InterruptedException e) {}
+
+            output = getResult(sonarBuildTaskIdUrl);
+            JSONObject taskObjects = JSONObject.fromObject(output);
+            status = taskObjects.getJSONObject("task").getString("status").toUpperCase();
+
+            ++count;
+
+            if (status.equals("FAILED") || status.equals("CANCELED")) {
+                logMessage = "[InfluxDB Plugin] Warning: Task has been " + status.toLowerCase() + "! Checkout SonarQube server's logs.";
+                listener.getLogger().println(logMessage);                   
+                break;
+            }
+
+            logMessage = "[InfluxDB Plugin] INFO: Task status: " + status;
+            listener.getLogger().println(logMessage);
+            
+        } while (!status.equals("SUCCESS") && count <= MAX_RETRY_COUNT);
+
+        if(!status.equals("SUCCESS")) {
+            logMessage = "[InfluxDB Plugin] WARNING: Timeout! Task status is still not SUCCESS. Getting results the latest completed task!";
+            listener.getLogger().println(logMessage);
+        }
     }
 
     private void setSonarDetails(String sonarBuildLink) {
@@ -132,6 +192,9 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 
         Point point = null;
         try {
+
+            waitForQualityGate();
+
             point = buildPoint("sonarqube_data", customPrefix, build)
                     .addField(BUILD_DISPLAY_NAME, build.getDisplayName())
                     .addField(SONARQUBE_CRITICAL_ISSUES, getSonarIssues(sonarIssuesUrl, "CRITICAL"))
@@ -154,7 +217,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                     .addField(SONARQUBE_TECHNICAL_DEBT_RATIO, getSonarMetric(sonarMetricsUrl, SONARQUBE_TECHNICAL_DEBT_RATIO))
                     .build();
         } catch (IOException e) {
-            String logMessage = "[InfluxDB Plugin] INFO: IOException while fetching SonarQube metrics: " + e.getMessage();
+            String logMessage = "[InfluxDB Plugin] Warning: IOException while fetching SonarQube metrics: " + e.getMessage();
             listener.getLogger().println(logMessage);
             e.printStackTrace(listener.getLogger());
         }
@@ -181,22 +244,34 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         }
     }
 
-    private String getSonarProjectURLFromBuildLogs(Run<?, ?> build) throws IOException {
+    private String[] getSonarProjectURLFromBuildLogs(Run<?, ?> build) throws IOException {
         String url = null;
+        String taskid = null;
+
         try (BufferedReader br = new BufferedReader(build.getLogReader())) {
             String line;
-            Pattern p = Pattern.compile(URL_PATTERN_IN_LOGS);
+            Pattern p_url = Pattern.compile(URL_PATTERN_IN_LOGS);
+            Pattern p_task = Pattern.compile(TASK_ID_PATTERN_IN_LOGS);
             while ((line = br.readLine()) != null) {
-                Matcher match = p.matcher(line);
+                Matcher match = p_url.matcher(line);
                 if (match.matches()) {
                     url = match.group(1);
+                } else {
+                    match = p_task.matcher(line);
+                    if (match.matches()) {
+                        taskid = match.group(1);
+                        break; // No need to search for other lines
+                    } 
                 }
             }
         }
-        return url;
+
+        String[] rtr_str_array = {url, taskid}; //return string array
+
+        return rtr_str_array;
     }
 
-    String getSonarProjectName(String url) throws URISyntaxException {
+    public String getSonarProjectName(String url) throws URISyntaxException {
         //String sonarVersion = getResult("api/server/version");
         URI uri = new URI(url);
         String[] projectUrl;
@@ -224,6 +299,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private String getSonarMetricValue(String url, String metric) throws IOException {
 
         String value = "";
+
         String output = getResult(url + SONAR_METRICS_BASE_METRIC + metric);
         JSONObject metricsObjects = JSONObject.fromObject(output);
         try {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -44,8 +44,8 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String SONARQUBE_TECHNICAL_DEBT = "sqale_index";
     private static final String SONARQUBE_TECHNICAL_DEBT_RATIO = "sqale_debt_ratio";
 
-    private final short DEFAULT_MAX_RETRY_COUNT = 10;
-    private final int DEFAULT_RETRY_SLEEP = 5000;
+    private static final short DEFAULT_MAX_RETRY_COUNT = 10;
+    private static final int DEFAULT_RETRY_SLEEP = 5000;
 
     private static final String URL_PATTERN_IN_LOGS = ".*" + Pattern.quote("ANALYSIS SUCCESSFUL, you can browse ")
             + "(.*)";

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -271,7 +271,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         return rtr_str_array;
     }
 
-    public String getSonarProjectName(String url) throws URISyntaxException {
+    String getSonarProjectName(String url) throws URISyntaxException {
         //String sonarVersion = getResult("api/server/version");
         URI uri = new URI(url);
         String[] projectUrl;


### PR DESCRIPTION
We have observed that the `influxdb` plugin doesn't always fetch the latest sonar measurements from the SonarQube server. So, in the current behavior, the plugin doesn't wait until a running Quality Gate task, which is triggered by the running Jenkins job, has been completed. It just gets the sonar measurements from the latest success (finished) task result. In short, we need to ensure that the `influxdb` plugin always fetches the results from the triggered pipeline, not from the previous successful one.

With this merge request, the plugin will wait until the triggered task has been completed. 

An example screenshot:

![image](https://user-images.githubusercontent.com/7557299/101750736-79792580-3ae0-11eb-805e-4c93145d821b.png)


Also, if the task status is not `SUCCESS` or the timeout has been expired, it'll log a `Warning` to the console. 