### PR TITLE
JENKINS-65115 Fix JUnit test name to be full name

### DIFF
--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -68,7 +68,9 @@ In order to publish data for this measurement, your job needs to set an environm
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
 | suite_name | string | Testsuite name | |
-| test_name | string | Test name | |
+| test_name | string | Test function name | Changed in 3.0 |
+| test_full_class_name | string | Test fully-qualified class name (`pacakge.ClassName`) | 3.0 |
+| pipeline_step | string | Pipeline steps, separated by ` / ` | 3.0 |
 | test_status | string | PASSED, SKIPPED, FAILED, FIXED, REGRESSION | |
 | test_status_ordinal | integer | 0-4 in order of test_status | |
 | test_duration | float | test duration in seconds | |
@@ -78,7 +80,9 @@ Tags specific for this measurement:
 | Tag | Description | Introduced in |
 | --- | --- | --- |
 | suite_name | Testsuite name | |
-| test_name | Test name | |
+| test_name | Test function name | Changed in 3.0 |
+| test_full_class_name | Test fully-qualified class name (`pacakge.ClassName`) | 3.0 |
+| pipeline_step | Pipeline steps, separated by ` / ` | 3.0 |
 | test_status | Test result | |
 
 #### `sonarqube_data` (since 1.11)

--- a/doc/breaking_changes.md
+++ b/doc/breaking_changes.md
@@ -10,7 +10,11 @@ Manage Jenkins --> Configure System.
      `target.username` and `target.password`.
   - JCasC configurations need to be modified, so that they use `credentialsId` instead of `username`
       and `password`.
-- JUnit names changed from name to fullname. Test names now include the package and class name of the test.
+- JUnit `test_name` field/tag changed to remove pipeline name. If your pipeline had multiple `junit` steps, 
+the pipeline step information is now recorded in the `pipeline_step` field/tag. For example:
+  - Before <br>`test_name`: `Tests / Test Stage 1 / my_test_name`
+  - After  <br>`test_name`: `my_test_name` <br> `test_full_class_name`: `mypackage.MyClass` <br> `pipeline_step`: `Tests / Test Stage 1`
+
 
 ## 2.0
 

--- a/doc/breaking_changes.md
+++ b/doc/breaking_changes.md
@@ -10,6 +10,7 @@ Manage Jenkins --> Configure System.
      `target.username` and `target.password`.
   - JCasC configurations need to be modified, so that they use `credentialsId` instead of `username`
       and `password`.
+- JUnit names changed from name to fullname. Test names now include the package and class name of the test.
 
 ## 2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.10</version>
+            <version>1.23</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
@@ -53,12 +53,12 @@ public class JUnitPointGenerator extends AbstractPointGenerator{
         for (CaseResult caseResult : allTestResults) {
             Point point = buildPoint("junit_data", customPrefix, build)
                     .addField(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
-                    .addField(JUNIT_TEST_NAME, caseResult.getDisplayName())
+                    .addField(JUNIT_TEST_NAME, caseResult.getFullDisplayName())
                     .addField(JUNIT_TEST_STATUS, caseResult.getStatus().toString())
                     .addField(JUNIT_TEST_STATUS_ORDINAL, caseResult.getStatus().ordinal())
                     .addField(JUNIT_DURATION, caseResult.getDuration())
                     .addTag(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
-                    .addTag(JUNIT_TEST_NAME, caseResult.getDisplayName())
+                    .addTag(JUNIT_TEST_NAME, caseResult.getFullDisplayName())
                     .addTag(JUNIT_TEST_STATUS, caseResult.getStatus().toString());
             points.add(point);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
@@ -7,6 +7,8 @@ import hudson.model.TaskListener;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AbstractTestResultAction;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.apache.commons.collections.iterators.ReverseListIterator;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +17,8 @@ public class JUnitPointGenerator extends AbstractPointGenerator{
 
     private static final String JUNIT_SUITE_NAME = "suite_name";
     private static final String JUNIT_TEST_NAME = "test_name";
+    private static final String JUNIT_TEST_CLASS_FULL_NAME = "test_class_full_name";
+    private static final String JUNIT_PIPELINE_STEP = "pipeline_step";
     private static final String JUNIT_TEST_STATUS = "test_status";
     private static final String JUNIT_TEST_STATUS_ORDINAL = "test_status_ordinal";
     private static final String JUNIT_DURATION = "test_duration";
@@ -53,17 +57,28 @@ public class JUnitPointGenerator extends AbstractPointGenerator{
         for (CaseResult caseResult : allTestResults) {
             Point point = buildPoint("junit_data", customPrefix, build)
                     .addField(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
-                    .addField(JUNIT_TEST_NAME, caseResult.getFullDisplayName())
+                    .addField(JUNIT_TEST_NAME, caseResult.getSimpleName())
+                    .addField(JUNIT_TEST_CLASS_FULL_NAME, caseResult.getClassName())
+                    .addField(JUNIT_PIPELINE_STEP, getCaseResultEnclosingFlowNodeString(caseResult))
                     .addField(JUNIT_TEST_STATUS, caseResult.getStatus().toString())
                     .addField(JUNIT_TEST_STATUS_ORDINAL, caseResult.getStatus().ordinal())
                     .addField(JUNIT_DURATION, caseResult.getDuration())
                     .addTag(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
-                    .addTag(JUNIT_TEST_NAME, caseResult.getFullDisplayName())
+                    .addTag(JUNIT_TEST_NAME, caseResult.getSimpleName())
+                    .addTag(JUNIT_TEST_CLASS_FULL_NAME, caseResult.getClassName())
+                    .addTag(JUNIT_PIPELINE_STEP, getCaseResultEnclosingFlowNodeString(caseResult))
                     .addTag(JUNIT_TEST_STATUS, caseResult.getStatus().toString());
             points.add(point);
         }
 
         return points.toArray(new Point[0]);
+    }
+
+    private String getCaseResultEnclosingFlowNodeString(CaseResult caseResult) {
+        if(caseResult.getEnclosingFlowNodeNames().isEmpty()) {
+            return StringUtils.join(new ReverseListIterator(caseResult.getEnclosingFlowNodeNames()), " / ");
+        }
+        return "";
     }
 
     private List<CaseResult> getAllTestResults(Run<?, ?> build) {


### PR DESCRIPTION
JUnit test names are missing the package and class names. Since this may be breaking, I put it to be included in the 3.0 release. 

Junit names include the stage closure and the test function name, but not the test package or class. This can be confusing when multiple tests exist with the same function name, but different classes or package paths. 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
