### PR TITLE
Revert back from using UrlValidator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,11 +167,6 @@ THE SOFTWARE.
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
         </dependency>
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
-        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -263,16 +258,6 @@ THE SOFTWARE.
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.8</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-digester</groupId>
-            <artifactId>commons-digester</artifactId>
-            <version>2.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -18,8 +18,8 @@ import jenkinsci.plugins.influxdb.models.Target;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
-import org.apache.commons.validator.routines.UrlValidator;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import java.util.logging.Level;
@@ -278,8 +278,9 @@ public class InfluxDbPublicationService {
         }
 
         for (Target target : selectedTargets) {
-            UrlValidator validator = new UrlValidator(new String[] {"http", "https"}, UrlValidator.ALLOW_LOCAL_URLS);
-            if (!validator.isValid(target.getUrl())) {
+            try {
+                new URL(target.getUrl());
+            } catch (MalformedURLException e) {
                 String logMessage = String.format("[InfluxDB Plugin] Skipping target '%s' due to invalid URL '%s'",
                         target.getDescription(),
                         target.getUrl());


### PR DESCRIPTION
Using UrlValidator introduced new insecure dependencies. Trying to solve those caused unit tests to fail with no real help from Google. This PR reverts away from UrlValidator to old logic.