### PR TITLE
[SonarQube] Reduce pager size to 1 of SONAR_ISSUES_BASE_URL

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -54,7 +54,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String TASK_ID_PATTERN_IN_LOGS = ".*" + Pattern.quote("More about the report processing at ")
             + "(.*)";
 
-    private static final String SONAR_ISSUES_BASE_URL = "/api/issues/search?ps=500&projectKeys=";
+    private static final String SONAR_ISSUES_BASE_URL = "/api/issues/search?ps=1&projectKeys=";
 
     // SonarQube 5.4+ expects componentKey=, SonarQube 8.1 expects component=, we
     // can make both of them happy


### PR DESCRIPTION
On some projects with many issues on SonarQube their retrieving can take several minutes.
I can see the parameter **pageSize** is set to 500, since the result of the request is only used to get the total of issues, is not necessary to specify a high value.
I've checked with few projects and different page size and the total value is still the same.
I may have forgotten something.
