### PR TITLE
Version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <properties>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
-        <jenkins.version>2.195</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <mailer.version>1.20</mailer.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
@@ -70,6 +70,10 @@ THE SOFTWARE.
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+		<repository>
+			<id>maven.jenkins-ci.org</id>
+			<url>https://repo.jenkins-ci.org/releases/</url>
+		</repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -83,7 +87,7 @@ THE SOFTWARE.
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
-                <version>1.17</version>
+                <version>1.22</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
@@ -159,13 +163,13 @@ THE SOFTWARE.
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.35</version>
+            <version>1.48</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.11</version>
         </dependency>
 
         <dependency>
@@ -177,7 +181,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.16</version>
+            <version>2.3.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Update credentials plugin dependency due to security issue and then fix transitive dependencies.

See #119 for details.