### PR TITLE
JENKINS-65692: Update SONAR_ISSUES_BASE_URL to change 'projectKeys' to 'projects'

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -54,7 +54,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String TASK_ID_PATTERN_IN_LOGS = ".*" + Pattern.quote("More about the report processing at ")
             + "(.*)";
 
-    private static final String SONAR_ISSUES_BASE_URL = "/api/issues/search?ps=1&projectKeys=";
+    private static final String SONAR_ISSUES_BASE_URL = "/api/issues/search?ps=1&projects=";
 
     // SonarQube 5.4+ expects componentKey=, SonarQube 8.1 expects component=, we
     // can make both of them happy


### PR DESCRIPTION
Fix for JENKINS-65692 - updated SONAR_ISSUSE_BASE_URL to change "projectKeys" to "projects" per Sonaqube api documentation found at this location https://SONARHOST/web_api/api/projects/search.  Using "projectKeys" (or anything else) will return the metrics for all projects.

https://issues.jenkins.io/browse/JENKINS-65692

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
