### PR TITLE
In relation to JENKINS-67519, fix user/pass based authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>com.influxdb</groupId>
             <artifactId>influxdb-client-java</artifactId>
-            <version>1.15.0</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -266,7 +266,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
This plugin no longer works with version 2.1.1 of Influxdb.  Given token based auth isn't supported yet, the only way to connect previously was with user/pass credentials.

With version 2.1.1 of Influxdb, this resulted in an UnauthorizedException despite the correct credentials being used.  The fix itself was just to upgrade to the most recent version of influxdb-client-java.  Moving from version 1.15.0 (~1 year old) to 4.1.0 which was released in January 2022.

I also had to update the version of gson being used as it was being picked up by the upperbounds mvn check.