### PR TITLE
[Jenkins 67718] - Fix SonarQube affecting builds with no SonarQube in use

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -111,7 +111,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             sonarBuildTaskIdUrl = result[3];
             
             return !StringUtils.isEmpty(sonarBuildURL);
-        } catch (Exception ignored) {}
+        } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {}
 
         return false;
     }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -1,10 +1,7 @@
 package jenkinsci.plugins.influxdb.generators;
 
-import java.io.BufferedReader;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.io.InputStreamReader;
-import java.io.FileInputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,7 +111,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             sonarBuildTaskIdUrl = result[3];
             
             return !StringUtils.isEmpty(sonarBuildURL);
-        } catch (IOException | IndexOutOfBoundsException ignored) {}
+        } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {}
 
         return false;
     }
@@ -248,7 +245,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         }
     }
 
-    private String[] getSonarProjectFromBuildReport() throws IOException {    
+    private String[] getSonarProjectFromBuildReport() throws IOException, UncheckedIOException {
         String projName = null;
         String url = null;
         String taskId = null;
@@ -302,7 +299,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     }
 
     public List<Path> findReportByFileName(String workspacePath)
-            throws IOException {
+            throws IOException, UncheckedIOException {
 
         Path path = Paths.get(workspacePath);                
         String reportName = env.get("SONARQUBE_BUILD_REPORT_NAME", 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -111,7 +111,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             sonarBuildTaskIdUrl = result[3];
             
             return !StringUtils.isEmpty(sonarBuildURL);
-        } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {}
+        } catch (Exception ignored) {}
 
         return false;
     }
@@ -251,10 +251,10 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         String taskId = null;
         String taskUrl = null;
 
-        String workspaceDir = env.get("WORKSPACE", "");
-        List<Path> reportsPaths = this.findReportByFileName(workspaceDir);
+        String workspaceDir = env.get("WORKSPACE");
+        List<Path> reportsPaths = workspaceDir == null ? null : this.findReportByFileName(workspaceDir);
         
-        if (reportsPaths.size() != 1) {
+        if (reportsPaths == null || reportsPaths.size() != 1) {
             return new String[]{null, null, null, null};
         }
         String reportFilePath = reportsPaths.get(0).toFile().getPath();

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
@@ -202,10 +202,10 @@ public class SonarQubePointGeneratorTest {
         try {
             
             String parentCustomDir = customReportPath[customReportPath.length - 1];
-            Path customReportPathPatttern = Paths.get(parentCustomDir, 
+            Path customReportPathPattern = Paths.get(parentCustomDir,
                                                     customReportName);
                                                     
-            Mockito.doReturn(customReportPathPatttern.toString())
+            Mockito.doReturn(customReportPathPattern.toString())
                 .when(envVars)
                 .get(any(String.class));
 


### PR DESCRIPTION
Change introduced in #123 caused the plugin to potentially search through the entire file system causing a high CPU usage and access denied errors. This change ensures the plugin only checks the build workspace.