### PR TITLE
updated getSonarProjectFromBuildReport to handle analysis URL that is…

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -302,6 +302,10 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                 match = p_analysis_url.matcher(line);
                 if (match.matches()) {
                     url  = match.group(1);
+                    long count = url.chars().filter(ch -> ch == '/').count();
+                    if (count >=3) {
+                        url = url.substring(0,url.lastIndexOf(('/')));
+                    }
                     continue;
                 }
                 match = p_taskUrl.matcher(line);


### PR DESCRIPTION
… provided by sonarqube 9.3 which includes /dashboard?id=.." in the URL

<!-- Please describe your pull request here. -->
Sonarqube Analysis url from Sonarqube 9.3 in the build log has the following structure:  
INFO: ANALYSIS SUCCESSFUL, you can browse https://sonarqube.xxx.com/dashboard?id=XXX.Web

The current logic just appends the api call after the "/dashboard?id=XXX.Web".  This new logic checks to see if there are three "/" chars in the url and if there are, it grabs the url prior to the 3rd "/".  It should not touch the URL if there are only 2 slashes as in "https://sonarqube.xyz.com"  (although I am unable to test this, I'm hoping @kumbasar can check this for me in his installation).

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
  https://github.com/jenkinsci/influxdb-plugin/pull/129
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
