### PR TITLE
change token to credentials for sonarqube

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -97,8 +97,6 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private final String customPrefix;
     private final TaskListener listener;
 
-    private String credentialId = null;
-
     private StringCredentials sonarqubeCredentials;
 
     private EnvVars env;
@@ -208,7 +206,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
 
         sonarMetricsUrl = sonarServer + String.format(SONAR_METRICS_BASE_URL, projectKey, projectKey);
 
-        credentialId = env.get("SONAR_AUTH_TOKEN");
+        String credentialId = env.get("SONAR_AUTH_TOKEN");
         if (credentialId != null) {
             String logMessage = "[InfluxDB Plugin] INFO: Using SonarQube auth token found in environment variable SONAR_AUTH_TOKEN";
             listener.getLogger().println(logMessage);

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -8,12 +8,10 @@ import java.util.regex.Pattern;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.influxdb.client.write.Point;
 import hudson.EnvVars;
@@ -26,10 +24,8 @@ import okhttp3.ResponseBody;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
-import hudson.model.ItemGroup;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.security.ACL;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 


### PR DESCRIPTION
Link to #150 

This PR change Sonarqube token to Jenkins credentials. 

The environnement variable doesn't change but must refers to a valid credentailsId.
The credentials type is a StringCredentials and it must be set in the context of the Job and contains the token to connect to Sonarqube.