### PR TITLE
add metrics to existing ones

### DIFF
--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -5,9 +5,11 @@ All measurements share the following metrics:
 
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
+| instance | string | Jenkins instance url |  |
 | build_number | integer | Build number |  |
 | project_name | string | Build name |  |
 | project_path | string | Build path | 1.15 |
+| project_namespace | string | Root path to the project (parent folder) |  |
 
 All measurements share the following tags:
 
@@ -28,6 +30,7 @@ All measurements share the following tags:
 | --- | --- | --- | --- |
 | build_agent_name | string | Name of the executor node | 1.15 |
 | build_branch_name | string | Branch name of multibranch pipeline | 2.4 |
+| build_cause | string | Trigger type |  |
 | build_causer | string | Short description of build causer| 2.4 |
 | build_exec_time | integer | Start time of the build | 1.17 |
 | build_measured_time | integer | Time when InfluxDB plugin is called | 1.17 |
@@ -37,6 +40,7 @@ All measurements share the following tags:
 | build_status_message | string | Status message (stable, back to normal, broken since #50, etc.) | |
 | build_successful | boolean | Boolean whether build succeeded | 1.10 |
 | build_time | integer | Build execution time |  |
+| build_user | string | User who launch the build |  |
 | last_stable_build | integer | Build number of the last stable build (0 if never) | 1.10 |
 | last_successful_build | integer | Build number of the last successful build (0 if never) | 1.10 |
 | project_build_health | integer | Health score from build | |

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -5,11 +5,11 @@ All measurements share the following metrics:
 
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
-| instance | string | Jenkins instance url | 3.4 |
 | build_number | integer | Build number |  |
+| instance | string | Jenkins instance url | 3.4 |
 | project_name | string | Build name |  |
+| project_namespace | string | Root folder of the project | 3.4 |
 | project_path | string | Build path | 1.15 |
-| project_namespace | string | Root path to the project (parent folder) | 3.4 |
 
 All measurements share the following tags:
 

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -5,11 +5,11 @@ All measurements share the following metrics:
 
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
-| instance | string | Jenkins instance url |  |
+| instance | string | Jenkins instance url | 3.4 |
 | build_number | integer | Build number |  |
 | project_name | string | Build name |  |
 | project_path | string | Build path | 1.15 |
-| project_namespace | string | Root path to the project (parent folder) |  |
+| project_namespace | string | Root path to the project (parent folder) | 3.4 |
 
 All measurements share the following tags:
 
@@ -30,7 +30,7 @@ All measurements share the following tags:
 | --- | --- | --- | --- |
 | build_agent_name | string | Name of the executor node | 1.15 |
 | build_branch_name | string | Branch name of multibranch pipeline | 2.4 |
-| build_cause | string | Trigger type |  |
+| build_cause | string | Trigger type | 3.4 |
 | build_causer | string | Short description of build causer| 2.4 |
 | build_exec_time | integer | Start time of the build | 1.17 |
 | build_measured_time | integer | Time when InfluxDB plugin is called | 1.17 |
@@ -40,7 +40,7 @@ All measurements share the following tags:
 | build_status_message | string | Status message (stable, back to normal, broken since #50, etc.) | |
 | build_successful | boolean | Boolean whether build succeeded | 1.10 |
 | build_time | integer | Build execution time |  |
-| build_user | string | User who launch the build |  |
+| build_user | string | User who launch the build | 3.4 |
 | last_stable_build | integer | Build number of the last stable build (0 if never) | 1.10 |
 | last_successful_build | integer | Build number of the last successful build (0 if never) | 1.10 |
 | project_build_health | integer | Health score from build | |

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@ THE SOFTWARE.
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs-annotations.version>4.2.0</spotbugs-annotations.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
+        <sshd.version>3.0</sshd.version>
         <structs.version>1.23</structs.version>
         <symbol-annotation.version>1.10</symbol-annotation.version>
         <workflow-api.version>2.33</workflow-api.version>
@@ -223,6 +224,12 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow-step-api.version}</version>
+        </dependency>
+        <dependency>
+             <groupId>org.jenkins-ci.modules</groupId>
+             <artifactId>sshd</artifactId>
+            <version>${sshd.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Optional dependencies -->

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -43,8 +43,9 @@ public abstract class AbstractPointGenerator implements PointGenerator {
 
     @Override
     public Point buildPoint(String name, String customPrefix, Run<?, ?> build, long timestamp) {
+        Jenkins instance = Jenkins.getInstanceOrNull();
         String projectName = projectNameRenderer.render(build);
-        String projectPath = build.getParent().getRelativeNameFrom(Jenkins.getInstanceOrNull());
+        String projectPath = build.getParent().getRelativeNameFrom(instance);
 
         Point point = Point
                 .measurement(name)
@@ -59,7 +60,7 @@ public abstract class AbstractPointGenerator implements PointGenerator {
 
         point.addTag(PROJECT_NAME, projectName);
         point.addTag(PROJECT_PATH, projectPath);
-        point.addTag(INSTANCE, Jenkins.getInstanceOrNull() != null ? Jenkins.getInstanceOrNull().getRootUrl() : null);
+        point.addTag(INSTANCE, instance != null ? instance.getRootUrl() : "");
         point.addTag(PROJECT_NAMESPACE, projectPath.split("/")[0]);
 
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -19,8 +19,10 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractPointGenerator implements PointGenerator {
 
+    public static final String PROJECT_NAMESPACE = "project_namespace";
     public static final String PROJECT_NAME = "project_name";
     public static final String PROJECT_PATH = "project_path";
+    public static final String INSTANCE = "instance";
     public static final String BUILD_NUMBER = "build_number";
     public static final String CUSTOM_PREFIX = "prefix";
 
@@ -57,6 +59,8 @@ public abstract class AbstractPointGenerator implements PointGenerator {
 
         point.addTag(PROJECT_NAME, projectName);
         point.addTag(PROJECT_PATH, projectPath);
+        point.addTag(INSTANCE, Jenkins.getInstanceOrNull() != null ? Jenkins.getInstanceOrNull().getRootUrl() : null);
+        point.addTag(PROJECT_NAMESPACE, projectPath.split("/")[0]);
 
 
         if (StringUtils.isNotBlank(jenkinsEnvParameterTag)) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -6,13 +6,19 @@ import hudson.model.Cause;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.Cause.UserIdCause;
 import hudson.tasks.test.AbstractTestResultAction;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
@@ -37,6 +43,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String BUILD_AGENT_NAME = "build_agent_name";
     public static final String BUILD_BRANCH_NAME = "build_branch_name";
     public static final String BUILD_CAUSER = "build_causer";
+    public static final String BUILD_USER = "build_user";
+    public static final String BUILD_CAUSE = "build_cause";
 
     public static final String PROJECT_BUILD_HEALTH = "project_build_health";
     public static final String PROJECT_LAST_SUCCESSFUL = "last_successful_build";
@@ -44,6 +52,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String TESTS_FAILED = "tests_failed";
     public static final String TESTS_SKIPPED = "tests_skipped";
     public static final String TESTS_TOTAL = "tests_total";
+
+    public static final String AGENT_LOG_PATTERN = "Running on ";
 
     private final Run<?, ?> build;
     private final String customPrefix;
@@ -87,6 +97,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             ordinal = buildResult.ordinal;
         }
 
+        String[] buildCause = getCauseDatas();
+
         Point point = buildPoint(measurementName, customPrefix, build);
 
         point.addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
@@ -97,12 +109,14 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             .addField(BUILD_RESULT, result)
             .addField(BUILD_RESULT_ORDINAL, ordinal)
             .addField(BUILD_IS_SUCCESSFUL, ordinal < 2)
-            .addField(BUILD_AGENT_NAME, getBuildEnv("NODE_NAME"))
+            .addField(BUILD_AGENT_NAME, getNodeName())
             .addField(BUILD_BRANCH_NAME, getBuildEnv("BRANCH_NAME"))
             .addField(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
             .addField(PROJECT_LAST_SUCCESSFUL, getLastSuccessfulBuild())
             .addField(PROJECT_LAST_STABLE, getLastStableBuild())
             .addField(BUILD_CAUSER , getCauseShortDescription())
+            .addField(BUILD_USER, buildCause[0])
+            .addField(BUILD_CAUSE, buildCause[1])
             .addTag(BUILD_RESULT, result);
 
         if (hasTestResults(build)) {
@@ -151,6 +165,24 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         }
     }
 
+    private String[] getCauseDatas() {
+        String userCause = "";
+        StringJoiner triggers = new StringJoiner(", ");
+        try {
+            for (Cause cause : build.getCauses()) {
+                triggers.add(cause.getClass().getSimpleName());
+                if (cause instanceof UserIdCause) {
+                    userCause = ((UserIdCause) cause).getUserId();
+                } else if (cause.getClass().getName().contains("GitlabWebhookCause")) {
+                    userCause = build.getEnvironment(listener).get("gitlabUserUsername");
+                }
+            }
+            return new String[] { userCause != null ? userCause : "", triggers.toString() };
+        } catch (Exception e) {
+            return new String[] { "", "" };
+        }
+    }
+
     private int getLastSuccessfulBuild() {
         Run<?, ?> lastSuccessfulBuild = build.getParent().getLastSuccessfulBuild();
         return lastSuccessfulBuild != null ? lastSuccessfulBuild.getNumber() : 0;
@@ -159,5 +191,34 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     private int getLastStableBuild() {
         Run<?, ?> lastStableBuild = build.getParent().getLastStableBuild();
         return lastStableBuild != null ? lastStableBuild.getNumber() : 0;
+    }
+
+    private String getNodeName() {
+        String nodeName = getBuildEnv("NODE_NAME");
+        if(StringUtils.isEmpty(nodeName)) {
+            nodeName = getNodeNameFromLogs();
+        }
+        return nodeName;
+    }
+
+    /**
+     * Retrieve agent name in the log of the build
+     * 
+     * @return agent name
+     */
+    private String getNodeNameFromLogs() {
+        String agentName = "";
+        try (BufferedReader br = new BufferedReader(build.getLogReader())) {
+            String line;
+            String[] splitLine;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith(AGENT_LOG_PATTERN)) {
+                    splitLine = line.split(" ");
+                    agentName = splitLine.length >= 3 ? splitLine[2] : "";
+                    break;
+                }
+            }
+        } catch (IOException e) {}
+        return agentName;
     }
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -178,7 +178,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
                 }
             }
             return new String[] { userCause != null ? userCause : "", triggers.toString() };
-        } catch (Exception e) {
+        } catch (IOException | InterruptedException e) {
             return new String[] { "", "" };
         }
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -91,7 +91,7 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite[1].toLineProtocol();
             lineProtocol2 = pointsToWrite[0].toLineProtocol();
         }
-        assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
-        assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test3=33i,test4=44i"));
+        assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
+        assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test3=33i,test4=44i"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -69,8 +69,8 @@ public class CustomDataPointGeneratorTest {
         Point[] pointsToWrite = cdGen.generate();
 
         String lineProtocol = pointsToWrite[0].toLineProtocol();
-        assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,tag1=myTag build_number=11i,build_time="));
-        assertTrue(lineProtocol.contains("project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
+        assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,tag1=myTag build_number=11i,build_time="));
+        assertTrue(lineProtocol.contains("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,tag1=myTag build_number=11i"));
     }
 
     @Test

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/MetricsPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/MetricsPointGeneratorTest.java
@@ -5,6 +5,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.metrics.impl.TimeInQueueAction;
+import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
@@ -38,6 +39,7 @@ public class MetricsPointGeneratorTest {
         Mockito.when(build.getParent()).thenReturn(job);
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
         Mockito.when(build.getAction(TimeInQueueAction.class)).thenReturn(timeInQueueAction);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
 
         currTime = System.currentTimeMillis();
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -95,9 +95,9 @@ public class PerfPublisherPointGeneratorTest {
         PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX);
         Point[] points = generator.generate();
 
-        assertTrue(points[0].toLineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,number_of_executed_tests=1i"));
-        assertTrue(points[1].toLineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
-        assertTrue(points[2].toLineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
-        assertTrue(points[3].toLineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
+        assertTrue(points[0].toLineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master build_number=11i,number_of_executed_tests=1i"));
+        assertTrue(points[1].toLineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
+        assertTrue(points[2].toLineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
+        assertTrue(points[3].toLineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
     }
 }


### PR DESCRIPTION
Link to #150 

This PR add somes metrics to existing ones and add improvments to existing functionnality.

Commons Points : 
* `instance` : Jenkins instance url
* `project_namespace` : root path to the project (parent folder)

Jenkins Points : 
* `build_user` : user who launch the build
* `build_cause` : Trigger type

Fix and improvments : 
* Research of `node_name` in logs if the env var isn't setted
* Fix `NoClassDefFoundException` in tests by adding sshd plugin (it was a module before, see [JEP-230](https://github.com/jenkinsci/jep/blob/master/jep/230/README.adoc))