### PR TITLE
Build log parse support for SonarScanner v4.8 

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -69,7 +69,13 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             + "(.*)";
     private static final String URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS = ".*" + Pattern.quote("QUALITY GATE STATUS: ") 
             + "(.*)" + Pattern.quote(" - View details on ") + "(.*)";
+    private static final String URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_v4_8 = ".*" + Pattern.quote("ANALYSIS SUCCESSFUL, you can find the results at: ") 
+            + "(.*)";
+    private static final String URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_TIMEOUT = ".*" + Pattern.quote("Quality Gate check timeout exceeded - View details on ") 
+            + "(.*)";
 
+
+            
     private String projectKey = null;
     private String sonarBuildURL = null;
     private String sonarBuildTaskIdUrl = null;
@@ -284,6 +290,9 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             Matcher match;
             Pattern p_analysis_url = Pattern.compile(URL_PATTERN_IN_LOGS_ANALYSIS);
             Pattern p_qg_url = Pattern.compile(URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS);
+            Pattern p_qg_url_timeout = Pattern.compile(URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_TIMEOUT);
+            Pattern p_qg_url_v4_8 = Pattern.compile(URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_v4_8);
+        
             Pattern p_taskUrl = Pattern.compile(TASK_URL_PATTERN_IN_LOGS);
             Pattern p_projName = Pattern.compile(PROJECT_NAME_PATTERN_IN_LOGS);
 
@@ -296,6 +305,18 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                 match = p_qg_url.matcher(line);
                 if (match.matches()) {
                     url  = match.group(2);
+                    //Task already executed.  No need to search for other lines
+                    break; 
+                }
+                match = p_qg_url_v4_8.matcher(line);
+                if (match.matches()) {
+                    url  = match.group(1);
+                    //Task already executed.  No need to search for other lines
+                    break; 
+                }
+                match = p_qg_url_timeout.matcher(line);
+                if (match.matches()) {
+                    url  = match.group(1);
                     //Task already executed.  No need to search for other lines
                     break; 
                 }


### PR DESCRIPTION
Within sonar-scanner v4.8, the build log where the SonarQube URL is parsed, has been changed:

**SonarScanner v4.6**:

```bash
 INFO: QUALITY GATE STATUS: PASSED - View details on https://prod.sonarqube.XXXXXX.net/dashboard?id=2178d27a-f5ff-4c1f-8faf-e7481cd92187&branch=develop
```

**SonarScanner v4.8**:

```bash
INFO: ANALYSIS SUCCESSFUL, you can find the results at: https://prod.sonarqube.XXXXXX.net/dashboard?id=63e375e6-0b19-4b9e-87d0-218a629fda9c&branch=develop
```

This pull request provides support to extract the SonarQube URL value from the build log for v4.8.

Successfully tested with following versions:

- SonarScanner 4.6.2.2472
![image](https://github.com/jenkinsci/influxdb-plugin/assets/7557299/563b8850-0cc8-4a72-8543-3529507e649c)

- SonarScanner 4.8.0.2856
![image](https://github.com/jenkinsci/influxdb-plugin/assets/7557299/ad3c984f-0f4f-4c12-88f8-3027cea1c3fc)


