### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,10 @@ static List<Map<String, String>> recommendedConfigurations() {
     def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         [ platform: "windows", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
+        [ platform: "linux", jdk: "8", jenkins: recentLTS ],
+        [ platform: "windows", jdk: "8", jenkins: recentLTS ],
+        [ platform: "linux", jdk: "11", jenkins: recentLTS ],
+        [ platform: "windows", jdk: "11", jenkins: recentLTS ]
     ]
     return configurations
 }


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge, once the infrastructure changes on ci.jenkins.io are live, to prevent a failure on the master branch and new PRs.