### PR TITLE
JENKINS-69384 - SerenityJsonSummaryFile: Add support for missing workspace

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFile.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFile.java
@@ -17,10 +17,17 @@ public class SerenityJsonSummaryFile implements ISerenityJsonSummaryFile {
     }
 
     public boolean exists() {
-        return Files.exists(getPath());
+        try {
+            return Files.exists(getPath());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     public Path getPath() {
+        if (workspace == null) {
+            throw new IllegalArgumentException("no workspace");
+        }
         return java.nio.file.Paths.get(workspace, SERENITY_OUTPUT_DIRECTORY, SERENITY_JSON_SUMMARY_FILE);
     }
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
@@ -67,7 +67,7 @@ public class SerenityPointGenerator extends AbstractPointGenerator {
     }
 
     public boolean hasReport() {
-        return (serenityJsonSummaryFile != null && serenityJsonSummaryFile.exists());
+        return serenityJsonSummaryFile.exists();
     }
 
     public Point[] generate() {

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFileTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFileTest.java
@@ -1,0 +1,54 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SerenityJsonSummaryFileTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testAvailableSummary() throws Exception {
+        writeToTemporaryPath("target/site/serenity/serenity-summary.json", "expected summary content");
+
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(pathOfTemporaryFolder());
+
+        assertTrue(serenityJsonSummaryFile.exists());
+        assertEquals("expected summary content", serenityJsonSummaryFile.getContents());
+    }
+
+    @Test
+    public void testUnavailableSummary() throws Exception {
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(pathOfTemporaryFolder());
+
+        assertFalse(serenityJsonSummaryFile.exists());
+    }
+
+    @Test
+    public void testUnavailableWorkspace() throws Exception {
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(null);
+
+        assertFalse(serenityJsonSummaryFile.exists());
+    }
+
+    private void writeToTemporaryPath(String path, String content) throws IOException {
+        Path temporaryPath = temporaryFolder.getRoot().toPath();
+        Path summaryJson = temporaryPath.resolve(path);
+        Files.createDirectories(summaryJson.getParent());
+        Files.writeString(summaryJson, content, StandardCharsets.UTF_8);
+    }
+
+    private String pathOfTemporaryFolder() {
+        return temporaryFolder.getRoot().getAbsolutePath();
+    }
+}


### PR DESCRIPTION
This fixes [JENKINS-69384](https://issues.jenkins.io/browse/JENKINS-69384) for me. It effectively adds the null check at the right spot to avoid calling `Paths.get()` without a valid workspace.

### Testing done

Automated test: Added a unit test for SerenityJsonSummaryFile that adds a bit of coverage for the happy path and also reproduces the problematic scenario described in JENKINS-69384: A non-existant workspace causes `workspace` to be null, which breaks the `SerenityJsonSummaryFile.exists()`-check on Java 17. This is due to a changed `Paths.get()` implementation that no longer silently accepts a null parameter.

Manual test: Installed the locally built plugin on a jenkins running Java 17 and could confirm, that the global collection trigger / outside of a workspace worked again:
```
[InfluxDB Plugin] Collecting data...
[InfluxDB Plugin] Git data found. Writing to InfluxDB...
[InfluxDB Plugin] Publishing data to target 'jenkins_data' (url='<my-influxdb-url>', database='dashboard')
[InfluxDB Plugin] Completed.
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

(Sorry, issues.jenkins.io appears to not accept logins right now or something else is weird, so I wasn't able to add a note in JENKINS-69384 pointing to this pr.)