### PR TITLE
Remove RF criticality metrics

### DIFF
--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -263,28 +263,28 @@ Tags specific for this measurement:
 
 #### `rf_results`
 
-| Metric | Type | Description | Introduced in |
-| --- | --- | --- | --- |
-| rf_critical_failed | integer | Amount of failed critical tests |  |
-| rf_critical_pass_percentage | float | Percentage of passed critical tests |  |
-| rf_critical_passed | integer | Amount of passed critical tests |  |
-| rf_critical_total | integer | Total amount of critical tests |  |
-| rf_duration | integer | Test execution duration |  |
-| rf_failed | integer | Amount of failed tests |  |
-| rf_pass_percentage | float | Percentage of passed tests |  |
-| rf_passed | integer | Amount of passed tests |  |
-| rf_suites | integer | Amount of test suites |  |
-| rf_skipped | integer | Amount of skipped tests | 3.0 |
-| rf_skip_percentage | float | Percentage of skipped tests | 3.0 |
-| rf_total | integer | Total amount of tests |  |
+| Metric | Type | Description                                                                                              | Introduced in |
+| --- | --- |----------------------------------------------------------------------------------------------------------| --- |
+| rf_critical_failed | integer | Amount of failed critical tests                                                                          | REMOVED IN 4.0 |
+| rf_critical_pass_percentage | float | Percentage of passed critical tests.<br/>Since 4.0 this is the total pass percentage including skipped tests. |  |
+| rf_critical_passed | integer | Amount of passed critical tests                                                                          | REMOVED IN 4.0 |
+| rf_critical_total | integer | Total amount of critical tests                                                                           | REMOVED IN 4.0 |
+| rf_duration | integer | Test execution duration                                                                                  |  |
+| rf_failed | integer | Amount of failed tests                                                                                   |  |
+| rf_pass_percentage | float | Percentage of passed tests, excuding skipped tests                                                       |  |
+| rf_passed | integer | Amount of passed tests                                                                                   |  |
+| rf_suites | integer | Amount of test suites                                                                                    |  |
+| rf_skipped | integer | Amount of skipped tests                                                                                  | 3.0 |
+| rf_skip_percentage | float | Percentage of skipped tests                                                                              | 3.0 |
+| rf_total | integer | Total amount of tests                                                                                    |  |
 
 #### `suite_result`
 
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
-| rf_critical_failed | integer | Amount of failed critical tests |  |
-| rf_critical_passed | integer | Amount of passed critical tests |  |
-| rf_critical_total | integer | Total amount of critical tests |  |
+| rf_critical_failed | integer | Amount of failed critical tests | REMOVED IN 4.0 |
+| rf_critical_passed | integer | Amount of passed critical tests | REMOVED IN 4.0 |
+| rf_critical_total | integer | Total amount of critical tests | REMOVED IN 4.0 |
 | rf_duration | integer | Test execution duration |  |
 | rf_failed | integer | Amount of failed tests |  |
 | rf_passed | integer | Amount of passed tests |  |
@@ -301,17 +301,17 @@ Tags specific for this measurement:
 
 #### `tag_point`
 
-| Metric | Type | Description | Introduced in |
-| --- | --- | --- | --- |
-| rf_critical_failed | integer | Amount of failed critical tests |  |
-| rf_critical_passed | integer | Amount of passed critical tests |  |
-| rf_critical_total | integer | Total amount of critical tests |  |
-| rf_duration | integer | Test execution duration |  |
-| rf_failed | integer | Amount of failed tests |  |
-| rf_passed | integer | Amount of passed tests |  |
-| rf_skipped | integer | Amount of skipped tests | 3.0 |
-| rf_total | integer | Total amount of tests |  |
-| rf_tag_name | string | Test tag name | 1.20.1 |
+| Metric | Type | Description | Introduced in   |
+| --- | --- | --- |-----------------|
+| rf_critical_failed | integer | Amount of failed critical tests | REMOVED IN 4.0 |
+| rf_critical_passed | integer | Amount of passed critical tests | REMOVED IN 4.0 |
+| rf_critical_total | integer | Total amount of critical tests | REMOVED IN 4.0  |
+| rf_duration | integer | Test execution duration |                 |
+| rf_failed | integer | Amount of failed tests |                 |
+| rf_passed | integer | Amount of passed tests |                 |
+| rf_skipped | integer | Amount of skipped tests | 3.0             |
+| rf_total | integer | Total amount of tests |                 |
+| rf_tag_name | string | Test tag name | 1.20.1          |
 
 Tags specific for this measurement:
 
@@ -321,17 +321,17 @@ Tags specific for this measurement:
 
 #### `testcase_point`
 
-| Metric | Type | Description | Introduced in |
-| --- | --- | --- | --- |
-| rf_critical_failed | integer | 0 or 1 |  |
-| rf_critical_passed | integer | 0 or 1 |  |
-| rf_duration | integer | Test case execution duration |  |
-| rf_failed | integer | 0 or 1 |  |
-| rf_name | string | Name of the test case |  |
-| rf_passed | integer | 0 or 1 |  |
-| rf_skipped | integer | 0 or 1 | 3.0 |
-| rf_suite_name | string | Name of the suite of the test case |  |
-| rf_age | int | How many times test has failed since last pass | 3.7 |
+| Metric | Type | Description | Introduced in  |
+| --- | --- | --- |----------------|
+| rf_critical_failed | integer | 0 or 1 | REMOVED IN 4.0 |
+| rf_critical_passed | integer | 0 or 1 | REMOVED IN 4.0 |
+| rf_duration | integer | Test case execution duration |                |
+| rf_failed | integer | 0 or 1 |                |
+| rf_name | string | Name of the test case |                |
+| rf_passed | integer | 0 or 1 |                |
+| rf_skipped | integer | 0 or 1 | 3.0            |
+| rf_suite_name | string | Name of the suite of the test case |                |
+| rf_age | int | How many times test has failed since last pass | 3.7            |
 
 Tags specific for this measurement:
 

--- a/doc/breaking_changes.md
+++ b/doc/breaking_changes.md
@@ -1,5 +1,12 @@
 # Breaking Changes
 
+## 4.0
+
+- Changes to Robot Framework metrics:
+  - All `rf_critical_*` metrics have been removed as criticality has been deprecated by the Robot Framework plugin.
+    - EXCEPT `rf_critical_pass_percentage`. It now sends the percentage of tests that passed including skipped tests.
+    - `rf_pass_percentage` continues behaviour as before and sends the percentage of tests that passed excluding skipped tests.
+
 ## 3.0
 
 - InfluxDB 1.7 and lower are no longer supported. Only supported 1.x version is 1.8.x.

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -21,9 +21,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     private static final String RF_PASSED = "rf_passed";
     private static final String RF_SKIPPED = "rf_skipped";
     private static final String RF_TOTAL = "rf_total";
-    private static final String RF_CRITICAL_FAILED = "rf_critical_failed";
-    private static final String RF_CRITICAL_PASSED = "rf_critical_passed";
-    private static final String RF_CRITICAL_TOTAL = "rf_critical_total";
     private static final String RF_CRITICAL_PASS_PERCENTAGE = "rf_critical_pass_percentage";
     private static final String RF_PASS_PERCENTAGE = "rf_pass_percentage";
     private static final String RF_SKIP_PERCENTAGE = "rf_skip_percentage";
@@ -68,9 +65,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
             .addField(RF_PASSED, robotBuildAction.getResult().getOverallPassed())
             .addField(RF_TOTAL, robotBuildAction.getResult().getOverallTotal())
             .addField(RF_SKIPPED, robotBuildAction.getResult().getOverallSkipped())
-            .addField(RF_CRITICAL_FAILED, robotBuildAction.getResult().getCriticalFailed())
-            .addField(RF_CRITICAL_PASSED, robotBuildAction.getResult().getCriticalPassed())
-            .addField(RF_CRITICAL_TOTAL, robotBuildAction.getResult().getCriticalTotal())
             .addField(RF_CRITICAL_PASS_PERCENTAGE, robotBuildAction.getCriticalPassPercentage())
             .addField(RF_PASS_PERCENTAGE, robotBuildAction.getOverallPassPercentage())
             .addField(RF_SKIP_PERCENTAGE, robotBuildAction.getResult().getSkipPercentage())
@@ -125,8 +119,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
             .addTag(RF_NAME, caseResult.getName())
             .addField(RF_NAME, caseResult.getName())
             .addField(RF_SUITE_NAME, caseResult.getParent().getName())
-            .addField(RF_CRITICAL_FAILED, caseResult.getCriticalFailed())
-            .addField(RF_CRITICAL_PASSED, caseResult.getCriticalPassed())
             .addField(RF_FAILED, caseResult.getFailed())
             .addField(RF_PASSED, caseResult.getPassed())
             .addField(RF_SKIPPED, caseResult.getSkipped())
@@ -147,8 +139,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         private int failed = 0;
         private int passed = 0;
         private int skipped = 0;
-        private long criticalFailed = 0;
-        private long criticalPassed = 0;
         private long duration = 0;
 
         private RobotTagResult(String name) {
@@ -165,8 +155,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
             tagResult.failed += caseResult.getFailed();
             tagResult.passed += caseResult.getPassed();
             tagResult.skipped += caseResult.getSkipped();
-            tagResult.criticalFailed += caseResult.getCriticalFailed();
-            tagResult.criticalPassed += caseResult.getCriticalPassed();
             tagResult.duration += caseResult.getDuration();
             tagResult.testCases.add(caseResult.getDuplicateSafeName());
         }
@@ -176,9 +164,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         return buildPoint("tag_point", customPrefix, build, timestamp)
             .addTag(RF_TAG_NAME, tagResult.name)
             .addField(RF_TAG_NAME, tagResult.name)
-            .addField(RF_CRITICAL_FAILED, (int)tagResult.criticalFailed)    // Send data as int for backwards compatibility
-            .addField(RF_CRITICAL_PASSED, (int)tagResult.criticalPassed)    // Send data as int for backwards compatibility
-            .addField(RF_CRITICAL_TOTAL, (int)(tagResult.criticalPassed + tagResult.criticalFailed))    // Send data as int for backwards compatibility
             .addField(RF_FAILED, tagResult.failed)
             .addField(RF_PASSED, tagResult.passed)
             .addField(RF_SKIPPED, tagResult.skipped)
@@ -191,9 +176,6 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
             .addTag(RF_SUITE_NAME, suiteResult.getName())
             .addField(RF_SUITE_NAME, suiteResult.getName())
             .addField(RF_TESTCASES, suiteResult.getAllCases().size())
-            .addField(RF_CRITICAL_FAILED, suiteResult.getCriticalFailed())
-            .addField(RF_CRITICAL_PASSED, suiteResult.getCriticalPassed())
-            .addField(RF_CRITICAL_TOTAL, suiteResult.getCriticalTotal())
             .addField(RF_FAILED, suiteResult.getFailed())
             .addField(RF_PASSED, suiteResult.getPassed())
             .addField(RF_SKIPPED, suiteResult.getSkipped())


### PR DESCRIPTION
Test criticality was removed in RF 4.0. The RF plugin has deprecated all criticality related methods. Stop sending criticality related data into InfluxDB.