### PR TITLE
Remove support for RF 3.X metrics

### DIFF
--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -263,20 +263,21 @@ Tags specific for this measurement:
 
 #### `rf_results`
 
-| Metric | Type | Description                                                                                              | Introduced in |
-| --- | --- |----------------------------------------------------------------------------------------------------------| --- |
-| rf_critical_failed | integer | Amount of failed critical tests                                                                          | REMOVED IN 4.0 |
-| rf_critical_pass_percentage | float | Percentage of passed critical tests.<br/>Since 4.0 this is the total pass percentage including skipped tests. |  |
-| rf_critical_passed | integer | Amount of passed critical tests                                                                          | REMOVED IN 4.0 |
-| rf_critical_total | integer | Total amount of critical tests                                                                           | REMOVED IN 4.0 |
-| rf_duration | integer | Test execution duration                                                                                  |  |
-| rf_failed | integer | Amount of failed tests                                                                                   |  |
-| rf_pass_percentage | float | Percentage of passed tests, excuding skipped tests                                                       |  |
-| rf_passed | integer | Amount of passed tests                                                                                   |  |
-| rf_suites | integer | Amount of test suites                                                                                    |  |
-| rf_skipped | integer | Amount of skipped tests                                                                                  | 3.0 |
-| rf_skip_percentage | float | Percentage of skipped tests                                                                              | 3.0 |
-| rf_total | integer | Total amount of tests                                                                                    |  |
+| Metric                      | Type | Description                                                                                                   | Introduced in  |
+|-----------------------------| --- |---------------------------------------------------------------------------------------------------------------|----------------|
+| rf_critical_failed          | integer | Amount of failed critical tests                                                                               | REMOVED IN 4.0 |
+| rf_critical_pass_percentage | float | Percentage of passed critical tests.<br/>Since 4.0 this is the total pass percentage including skipped tests. | REMOVED IN 5.0 |
+| rf_critical_passed          | integer | Amount of passed critical tests                                                                               | REMOVED IN 4.0 |
+| rf_critical_total           | integer | Total amount of critical tests                                                                                | REMOVED IN 4.0 |
+| rf_duration                 | integer | Test execution duration                                                                                       |                |
+| rf_failed                   | integer | Amount of failed tests                                                                                        |                |
+| rf_pass_percentage          | float | Percentage of passed tests, excuding skipped tests                                                            |                |
+| rf_pass_percentage_total    | float | Percentage of passed tests, including skipped tests                                                           | 5.0            |
+| rf_passed                   | integer | Amount of passed tests                                                                                        |                |
+| rf_suites                   | integer | Amount of test suites                                                                                         |                |
+| rf_skipped                  | integer | Amount of skipped tests                                                                                       | 3.0            |
+| rf_skip_percentage          | float | Percentage of skipped tests                                                                                   | 3.0            |
+| rf_total                    | integer | Total amount of tests                                                                                         |                |
 
 #### `suite_result`
 

--- a/doc/breaking_changes.md
+++ b/doc/breaking_changes.md
@@ -1,5 +1,11 @@
 # Breaking Changes
 
+## 5.0
+
+- Changes to Robt Framework metrics:
+  - `rf_critical_pass_percentage` has been removed. It has been replaced by `rf_pass_percentage_total`, 
+    which sends the percentage of tests that passed including skipped tests.
+
 ## 4.0
 
 - Changes to Robot Framework metrics:

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ THE SOFTWARE.
         <cobertura.version>1.17</cobertura.version>
         <performance.version>951.v5600a_c6422ed</performance.version>
         <perfpublisher.version>8.09</perfpublisher.version>
-        <robot.version>5.0.0</robot.version>
+        <robot.version>6.0.0</robot.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -21,8 +21,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
     private static final String RF_PASSED = "rf_passed";
     private static final String RF_SKIPPED = "rf_skipped";
     private static final String RF_TOTAL = "rf_total";
-    private static final String RF_CRITICAL_PASS_PERCENTAGE = "rf_critical_pass_percentage";
     private static final String RF_PASS_PERCENTAGE = "rf_pass_percentage";
+    private static final String RF_PASS_PERCENTAGE_TOTAL = "rf_pass_percentage_total";
     private static final String RF_SKIP_PERCENTAGE = "rf_skip_percentage";
     private static final String RF_DURATION = "rf_duration";
     private static final String RF_SUITES = "rf_suites";
@@ -65,8 +65,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
             .addField(RF_PASSED, robotBuildAction.getResult().getOverallPassed())
             .addField(RF_TOTAL, robotBuildAction.getResult().getOverallTotal())
             .addField(RF_SKIPPED, robotBuildAction.getResult().getOverallSkipped())
-            .addField(RF_CRITICAL_PASS_PERCENTAGE, robotBuildAction.getCriticalPassPercentage())
             .addField(RF_PASS_PERCENTAGE, robotBuildAction.getOverallPassPercentage())
+            .addField(RF_PASS_PERCENTAGE_TOTAL, robotBuildAction.getPassPercentageWithSkipped())
             .addField(RF_SKIP_PERCENTAGE, robotBuildAction.getResult().getSkipPercentage())
             .addField(RF_DURATION, robotBuildAction.getResult().getDuration())
             .addField(RF_SUITES, robotBuildAction.getResult().getAllSuites().size());


### PR DESCRIPTION
Criticality was removed in Robot Framework 4.0. The Robot Framework Jenkins plugin release 6.0.0 removed support for criticality. Bump dependency requirement for RF plugin to 6.0.0 and fix broken API call.

Introduce a new metric `rf_pass_percentage_total` to include all tests in pass percentage calculation.