### PR TITLE
Support AWS Timestream "dev" version string

### DIFF
--- a/src/main/java/jenkinsci/plugins/influxdb/models/InfluxDBClientWrapper.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/InfluxDBClientWrapper.java
@@ -41,6 +41,11 @@ public class InfluxDBClientWrapper {
      */
     private com.influxdb.v3.client.InfluxDBClient v3client;
 
+    /**
+     * Tracks which API version was successfully used for connection
+     */
+    private String connectedApiVersion;
+
     public InfluxDBClientWrapper(
             @Nonnull String url,
             @Nullable String organization,
@@ -91,15 +96,16 @@ public class InfluxDBClientWrapper {
                 options.authenticateToken(tokenCredentials.getSecret().getPlainText().toCharArray());
             }
             this.v1v2client = InfluxDBClientFactory.create(options.build());
-            if (this.v1v2client.ping() && this.getAPIVersion().startsWith("v2")) {
+            if (this.v1v2client.ping() && (this.getAPIVersion().startsWith("v2") || isMaybeValidVersion(this.getAPIVersion()))) {
                 logger.fine("Connection success");
+                this.connectedApiVersion = "v2";
                 success = true;
             } else {
                 this.v1v2client.close();
                 logger.fine("Connection failed");
             }
         } catch (InfluxException | AccessDeniedException | MalformedURLException e) {
-            logger.warning("Connection failed: " + e.getMessage());
+            logConnectionFailure(e, "v2");
         } finally {
             if (!success) {
                 this.closeAndResetAllClients();
@@ -124,8 +130,9 @@ public class InfluxDBClientWrapper {
                         .database(database)
                         .build();
                 this.v3client = com.influxdb.v3.client.InfluxDBClient.getInstance(config);
-                if (this.getAPIVersion().startsWith("3")) {
+                if (this.getAPIVersion().startsWith("3") || isMaybeValidVersion(this.getAPIVersion())) {
                     logger.fine("Connection success");
+                    this.connectedApiVersion = "v3";
                     success = true;
                 } else {
                     logger.fine("Connection failed");
@@ -134,8 +141,9 @@ public class InfluxDBClientWrapper {
             } else {
                 logger.fine("Token credentials not found, skipping InfluxDB v3.X API");
             }
-        } catch (Exception e) {
-            logger.warning("Connection failed: " + e.getMessage());
+        } catch (ExceptionInInitializerError | NoClassDefFoundError | Exception e) {
+            // catch influxdb v3 initialization failures or regular InfluxDB client exceptions
+            logConnectionFailure(e, "v3");
         } finally {
             if (!success) {
                 this.closeAndResetAllClients();
@@ -157,14 +165,15 @@ public class InfluxDBClientWrapper {
             }
             String apiVersion = this.getAPIVersion();
             // InfluxDB v1.11 returns v1.X instead of 1.X
-            if (this.v1v2client.ping() && (apiVersion.startsWith("1") || apiVersion.startsWith("v1"))) {
+            if (this.v1v2client.ping() && (apiVersion.startsWith("1") || apiVersion.startsWith("v1") || isMaybeValidVersion(apiVersion))) {
                 logger.fine("Connection success");
+                this.connectedApiVersion = "v1";
                 success = true;
             } else {
                 logger.fine("Connection failed");
             }
         } catch (InfluxException | AccessDeniedException e) {
-            logger.warning("Connection failed: " + e.getMessage());
+            logConnectionFailure(e, "v1");
         } finally {
             if (!success) {
                 this.closeAndResetAllClients();
@@ -204,6 +213,41 @@ public class InfluxDBClientWrapper {
         }
         logger.fine("API version: " + version);
         return version;
+    }
+
+    /**
+     * Returns which API version (v1, v2, or v3) was used to establish the connection.
+     *
+     * @return The API version used ("v1", "v2", or "v3")
+     */
+    public String getConnectedApiVersion() {
+        return this.connectedApiVersion;
+    }
+
+    /**
+     * Checks if a version string might be valid even if it doesn't match expected formats.
+     * Some cloud providers like AWS Timestream return "dev" instead of standard version strings.
+     *
+     * @param version The version string to check
+     * @return true if the version might be valid (e.g., "dev")
+     */
+    private boolean isMaybeValidVersion(String version) {
+        if (version == null) {
+            return false;
+        }
+        return version.equalsIgnoreCase("dev");
+    }
+
+    /**
+     * Logs connection failure with appropriate detail.
+     *
+     * @param error The exception or error that occurred
+     * @param apiVersion The API version being attempted (e.g., "v1", "v2", "v3")
+     */
+    private void logConnectionFailure(Throwable error, String apiVersion) {
+        // Simple message - just indicate which API didn't work and why
+        String reason = error.getClass().getSimpleName();
+        logger.info(apiVersion + " API not supported (" + reason + ")");
     }
 
     private void closeAndResetAllClients() {

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -242,8 +242,9 @@ public class Target extends AbstractDescribableImpl<Target> implements java.io.S
                         tokenCredentials,
                         usingJenkinsProxy
                 );
-                String apiVersion = client.getAPIVersion();
-                return FormValidation.ok("Connection success (API version " + apiVersion + ")");
+                String connectedApi = client.getConnectedApiVersion();
+                String serverVersion = client.getAPIVersion();
+                return FormValidation.ok("Connection success using " + connectedApi + " API (server version: " + serverVersion + ")");
             } catch (Exception e) {
                 return FormValidation.error(e, "Connection Failed");
             } finally {

--- a/src/test/java/jenkinsci/plugins/influxdb/models/InfluxDBClientWrapperTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/models/InfluxDBClientWrapperTest.java
@@ -1,0 +1,111 @@
+package jenkinsci.plugins.influxdb.models;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.InfluxDBClientOptions;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class InfluxDBClientWrapperTest {
+
+    @Test
+    void testV2ConnectionWithDevVersion() {
+        InfluxDBClient mockClient = mock(InfluxDBClient.class);
+        when(mockClient.ping()).thenReturn(true);
+        when(mockClient.version()).thenReturn("dev");
+
+        StringCredentials mockToken = mock(StringCredentials.class);
+        when(mockToken.getSecret()).thenReturn(Secret.fromString("test-token"));
+
+        try (MockedStatic<InfluxDBClientFactory> mockedFactory = Mockito.mockStatic(InfluxDBClientFactory.class)) {
+            mockedFactory.when(() -> InfluxDBClientFactory.create(any(InfluxDBClientOptions.class)))
+                .thenReturn(mockClient);
+
+            InfluxDBClientWrapper wrapper = new InfluxDBClientWrapper(
+                "https://example.com:8086",
+                "test-org",
+                "test-db",
+                null,
+                null,
+                mockToken,
+                false
+            );
+
+            assertNotNull(wrapper);
+            assertEquals("v2", wrapper.getConnectedApiVersion());
+            assertEquals("dev", wrapper.getAPIVersion());
+        }
+    }
+
+    @Test
+    void testV2ConnectionWithStandardVersion() {
+        InfluxDBClient mockClient = mock(InfluxDBClient.class);
+        when(mockClient.ping()).thenReturn(true);
+        when(mockClient.version()).thenReturn("v2.7.1");
+
+        StringCredentials mockToken = mock(StringCredentials.class);
+        when(mockToken.getSecret()).thenReturn(Secret.fromString("test-token"));
+
+        try (MockedStatic<InfluxDBClientFactory> mockedFactory = Mockito.mockStatic(InfluxDBClientFactory.class)) {
+            mockedFactory.when(() -> InfluxDBClientFactory.create(any(InfluxDBClientOptions.class)))
+                .thenReturn(mockClient);
+
+            InfluxDBClientWrapper wrapper = new InfluxDBClientWrapper(
+                "https://example.com:8086",
+                "test-org",
+                "test-db",
+                null,
+                null,
+                mockToken,
+                false
+            );
+
+            assertNotNull(wrapper);
+            assertEquals("v2", wrapper.getConnectedApiVersion());
+            assertEquals("v2.7.1", wrapper.getAPIVersion());
+        }
+    }
+
+    @Test
+    void testV1ConnectionWithDevVersion() {
+        InfluxDBClient mockClient = mock(InfluxDBClient.class);
+        when(mockClient.ping()).thenReturn(true);
+        when(mockClient.version()).thenReturn("dev");
+
+        StringCredentials mockToken = mock(StringCredentials.class);
+        when(mockToken.getSecret()).thenReturn(Secret.fromString("test-token"));
+
+        try (MockedStatic<InfluxDBClientFactory> mockedFactory = Mockito.mockStatic(InfluxDBClientFactory.class)) {
+            mockedFactory.when(() -> InfluxDBClientFactory.createV1(
+                any(String.class),
+                any(String.class),
+                any(char[].class),
+                any(String.class),
+                any()
+            )).thenReturn(mockClient);
+
+            InfluxDBClientWrapper wrapper = new InfluxDBClientWrapper(
+                "https://example.com:8086",
+                null,
+                "test-db",
+                "autogen",
+                null,
+                mockToken,
+                false
+            );
+
+            assertNotNull(wrapper);
+            assertEquals("v1", wrapper.getConnectedApiVersion());
+            assertEquals("dev", wrapper.getAPIVersion());
+        }
+    }
+}


### PR DESCRIPTION
Fix: Support AWS Timestream "dev" version string

### Problem:
  AWS Timestream returns "dev" as the InfluxDB version string, causing connection failures because the plugin only accepted standard
  version formats (v2.x, 3.x, v1.x).

### Solution:
  - Added isMaybeValidVersion() helper to accept non-standard version strings like "dev"
  - Updated v1, v2, and v3 connection logic to check for "dev" version
  - Improved connection success message to show which API version was used (e.g., "Connection success using v2 API (server version:
  dev)")
  - Added exception handling for v3 initialization errors (ExceptionInInitializerError, NoClassDefFoundError)
  - Added unit tests to verify "dev" version handling

### Testing:
  - Tested with AWS Timestream real instance successfully
  - Added 3 unit tests covering v2 and v1 connections with "dev" version

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
