### PR TITLE
Support SonarQube report from archived artifacts

### DIFF
--- a/doc/SonarQube_integration.md
+++ b/doc/SonarQube_integration.md
@@ -3,9 +3,15 @@
 ## Summary
 A short guideline on integrating Jenkins with SonarQube and verifying their integration.
 
-The SonarQubePointGenerator is expecting to find a sonar build report (report-task.txt) created by the scanner with the following content:
+The `SonarQubePointGenerator` resolves the SonarQube report (`report-task.txt`) in the following order:
+
+1. **Workspace file scan** — searches recursively under `$WORKSPACE` for the report file.
+2. **Archived artifact** — if the workspace is not accessible (e.g. when the publisher runs on the controller while the build ran on a remote agent), the plugin falls back to reading the report from the build's archived artifacts. Archive `report-task.txt` in your pipeline with `archiveArtifacts` to enable this path. This fallback currently relies on local artifact storage and does not work with jenkins S3-backed managers.
+3. **Build log parsing** — as a last resort, the plugin scans the console output for SonarQube scanner log lines that contain the required metadata.
+
+The report file is created by the SonarQube scanner and has the following content:
 ```
-file: ${WORKSPACE}/**/sonar/report-task.txt	
+file: ${WORKSPACE}/**/sonar/report-task.txt
 
 projectKey=com.tom:sonarqube-jacoco-code-coverage
 serverUrl=http://localhost:9000
@@ -15,9 +21,9 @@ ceTaskId=AX0vnvr4_QGKX8b7Yz_v
 ceTaskUrl=http://localhost:9000/api/ce/task?id=AX0vnvr4_QGKX8b7Yz_v
 ```
 
-The actual location of the report file in the workspace depends on the build system used - Maven, Gradle, etc. 
+The actual location of the report file in the workspace depends on the build system used - Maven, Gradle, etc.
 
-If, for whatever reason, a report file is created with a different name, the `SONARQUBE_BUILD_REPORT_NAME` env var 
+If, for whatever reason, a report file is created with a different name, the `SONARQUBE_BUILD_REPORT_NAME` env var
 could be used to specify either the file name or the path pattern ending with the file name.
 
 Examples:
@@ -27,31 +33,32 @@ Examples:
         SONARQUBE_BUILD_REPORT_NAME="custom-report.txt"
         # SONARQUBE_BUILD_REPORT_NAME="path/custom-report.txt"
     }
-    
+
     steps {
         withSonarQubeEnv('SonarQube') {
             influxDbPublisher(selectedTarget: 'influxdb_v2',)
         }
     }
   }
-``` 
+```
 
-The information extracted fron this file is used to query about SQ issues, measures and task status.
+The information extracted from this file is used to query SonarQube for issues, measures, and task status.
 
 # References
 1. [CloudBees Video on SonarQube integration with Jenkins](https://www.youtube.com/watch?v=KsTMy0920go)
 2. SonarQube WEB API: https://sonarcloud.io/web_api/
 
-## Verification 
-The plugin is using the following API calls 
+## Verification
+
+The plugin uses the following API calls:
+
 1. [Issues Search](https://sonarcloud.io/web_api/api/issues/search)
-2. [Measures Search Histhory](https://sonarcloud.io/web_api/api/measures/search_history)
-3. [Task CE status](https://sonarcloud.io/web_api/api/ce/task)
+2. [Measures Search History](https://sonarcloud.io/web_api/api/measures/search_history)
+3. [CE Task Status](https://sonarcloud.io/web_api/api/ce/task)
 
-After seetting up a security token in SonarQube use the following curl calls to verify manually the API integration
-with SonarQube.
+After setting up a security token in SonarQube, use the following curl commands to verify the API integration manually.
 
-### Measures Search Histhory
+### Measures Search History
 export TOKEN=****************
 curl -s -G -u ${TOKEN}: \
 --data-urlencode "componentKey=com.tom:sonarqube-jacoco-code-coverage" \
@@ -98,7 +105,7 @@ http://localhost:9000/api/issues/search?ps=1 | jq .
   "facets": []
 }
 ```
- 
+
 ### Task status
 export TOKEN=****************
 curl -s -G -u ${TOKEN}: \
@@ -130,15 +137,15 @@ http://localhost:9000/api/ce/task?id=AX0vnvr4_QGKX8b7Yz_v | jq .
 # A simple pipeline for testing
 ```
 pipeline {
-    agent any    
+    agent any
 
     stages {
         stage('Clone sources') {
             steps {
                 git url: 'https://github.com/dgeorgievski/sonarqube-jacoco-code-coverage.git'
             }
-        }        
-        
+        }
+
         stage('Build') {
             steps {
                 sh './gradlew clean test build'
@@ -146,7 +153,7 @@ pipeline {
                 step( [ $class: 'JacocoPublisher' ] )
             }
         }
-        
+
         stage('SonarQube analysis') {
             steps {
                 withSonarQubeEnv('SonarQube') {
@@ -154,26 +161,26 @@ pipeline {
                 }
             }
         }
-        
+
         stage("Quality gate") {
             steps {
                 waitForQualityGate abortPipeline: true
             }
         }
-        
+
         stage("InfluxDB v2 publisher") {
             environment {
                 LOG_JUNIT_RESULTS="true"
                 INFLUXDB_PLUGIN_CUSTOM_PROJECT_NAME = "foo"
             }
-            
+
             steps {
                 withSonarQubeEnv('SonarQube') {
                     influxDbPublisher(selectedTarget: 'influxdb_v2',)
                 }
             }
         }
-        
+
     }
 }
 ```

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -93,6 +93,8 @@ Tags specific for this measurement:
 
 #### `sonarqube_data` (since 1.11)
 
+See [sonarqube-integration](SonarQube_integration.md).
+
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
 | alert_status | string | State of the Quality Gate | 2.4 |

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -121,35 +121,41 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
      */
     public boolean hasReport() {
 
-        String[] result = null;
-
         try {
-            result = getSonarProjectFromBuildReport();
-            projectKey = result[0];
-            sonarBuildURL = result[1];
-            sonarBuildTaskId = result[2];
-            sonarBuildTaskIdUrl = result[3];
-
-            return !StringUtils.isEmpty(sonarBuildURL);
+            if (applySonarProjectResult(getSonarProjectFromBuildReport())) {
+                return true;
+            }
         } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {
         }
 
         try {
-            //try build logs
-            result = getSonarProjectFromBuildLog(build);
+            if (applySonarProjectResult(getSonarProjectFromBuildArtifact())) {
+                return true;
+            }
+        } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {
+        }
 
-            if (!StringUtils.isEmpty(result[1])) {
-                projectKey = result[0];
-                sonarBuildURL = result[1];
-                sonarBuildTaskId = result[2];
-                sonarBuildTaskIdUrl = result[3];
-
-                return !StringUtils.isEmpty(sonarBuildURL);
+        try {
+            if (applySonarProjectResult(getSonarProjectFromBuildLog(build))) {
+                return true;
             }
         } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {
         }
 
         return false;
+    }
+
+    private boolean applySonarProjectResult(String[] result) {
+        if (result == null || result.length < 4 || StringUtils.isEmpty(result[1])) {
+            return false;
+        }
+
+        projectKey = result[0];
+        sonarBuildURL = result[1];
+        sonarBuildTaskId = result[2];
+        sonarBuildTaskIdUrl = result[3];
+
+        return true;
     }
 
     public void setEnv(EnvVars env) {
@@ -351,18 +357,59 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     }
 
     private String[] getSonarProjectFromBuildReport() throws IOException, UncheckedIOException {
+        String workspaceDir = env.get("WORKSPACE");
+        Path reportPath = workspaceDir == null ? null : findSingleReportPath(Paths.get(workspaceDir));
+        if (reportPath == null) {
+            return new String[]{null, null, null, null};
+        }
+
+        return parseSonarProjectFromReportFile(reportPath.toFile().getPath());
+    }
+
+    private String[] getSonarProjectFromBuildArtifact() throws IOException, UncheckedIOException {
+        File artifactsDir = build.getArtifactsDir();
+        if (artifactsDir == null || !artifactsDir.exists() || !artifactsDir.isDirectory()) {
+            return new String[]{null, null, null, null};
+        }
+
+        Path reportPath = findSingleReportPath(artifactsDir.toPath());
+        if (reportPath == null) {
+            return new String[]{null, null, null, null};
+        }
+
+        return parseSonarProjectFromReportFile(reportPath.toFile().getPath());
+    }
+
+    private Path findSingleReportPath(Path rootPath) throws IOException, UncheckedIOException {
+        if (rootPath == null || !Files.exists(rootPath) || !Files.isDirectory(rootPath)) {
+            return null;
+        }
+
+        String reportName = env.get("SONARQUBE_BUILD_REPORT_NAME",
+                SONARQUBE_DEFAULT_BUILD_REPORT_NAME);
+
+        List<Path> reportsPaths;
+        try (Stream<Path> pathStream = Files.find(rootPath,
+                Integer.MAX_VALUE,
+                (p, basicFileAttributes) ->
+                        basicFileAttributes.isRegularFile() &&
+                    p.endsWith(reportName))
+        ) {
+            reportsPaths = pathStream.collect(Collectors.toList());
+        }
+
+        if (reportsPaths.size() != 1) {
+            return null;
+        }
+
+        return reportsPaths.get(0);
+    }
+
+    private String[] parseSonarProjectFromReportFile(String reportFilePath) throws IOException {
         String projName = null;
         String url = null;
         String taskId = null;
         String taskUrl = null;
-
-        String workspaceDir = env.get("WORKSPACE");
-        List<Path> reportsPaths = workspaceDir == null ? null : this.findReportByFileName(workspaceDir);
-
-        if (reportsPaths == null || reportsPaths.size() != 1) {
-            return new String[]{null, null, null, null};
-        }
-        String reportFilePath = reportsPaths.get(0).toFile().getPath();
 
         try (BufferedReader br = new BufferedReader(
                 new InputStreamReader(
@@ -401,23 +448,6 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         }
 
         return new String[]{projName, url, taskId, taskUrl};
-    }
-
-    public List<Path> findReportByFileName(String workspacePath)
-            throws IOException, UncheckedIOException {
-
-        Path path = Paths.get(workspacePath);
-        String reportName = env.get("SONARQUBE_BUILD_REPORT_NAME",
-                SONARQUBE_DEFAULT_BUILD_REPORT_NAME);
-
-        try (Stream<Path> pathStream = Files.find(path,
-                Integer.MAX_VALUE,
-                (p, basicFileAttributes) ->
-                        basicFileAttributes.isRegularFile() &&
-                                p.endsWith(reportName))
-        ) {
-            return pathStream.collect(Collectors.toList());
-        }
     }
 
     public String getSonarMetricStr(String url, String metric) throws IOException {

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -147,12 +146,12 @@ public class SonarQubePointGeneratorTest {
         Path sonarReport = wsSonarDir.resolve(defaultReportName);
 
         try {
-            List<Path> result = gen.findReportByFileName(wsRoot);
-            assertEquals(1, result.size());
+            Path result = invokeFindSingleReportPath(gen, Paths.get(wsRoot));
+            assertNotNull(result);
 
             Files.deleteIfExists(sonarReport);
-            result = gen.findReportByFileName(wsRoot);
-            assertEquals(0, result.size());
+            result = invokeFindSingleReportPath(gen, Paths.get(wsRoot));
+            assertNull(result);
         } catch (Exception e) {
             System.err.println("[InfluxDB Plugin Test] ERROR: Failed to find default report file - " + e.getMessage());
         }
@@ -162,7 +161,8 @@ public class SonarQubePointGeneratorTest {
     void getSonarCustomReportFileName() {
         // Find a custom report file defined by SONARQUBE_BUILD_REPORT_NAME env var
         // Example: custom-report.txt
-        EnvVars envVars = Mockito.spy(new EnvVars());
+        EnvVars envVars = new EnvVars();
+        envVars.put("SONARQUBE_BUILD_REPORT_NAME", customReportName);
 
         SonarQubePointGenerator gen = Mockito.spy(
                 new SonarQubePointGenerator(build,
@@ -176,14 +176,8 @@ public class SonarQubePointGeneratorTest {
         String wsRoot = folder.toString();
 
         try {
-
-            Mockito.doReturn(customReportName)
-                    .when(envVars)
-                    .get(any(String.class));
-
-            List<Path> result = gen.findReportByFileName(wsRoot);
-            assertEquals(1, result.size());
-
+            Path result = invokeFindSingleReportPath(gen, Paths.get(wsRoot));
+            assertNotNull(result);
         } catch (Exception e) {
             System.err.println("[InfluxDB Plugin Test] ERROR: Failed to find custom report file - " + e.getMessage());
         }
@@ -193,7 +187,7 @@ public class SonarQubePointGeneratorTest {
     void getSonarCustomReportFilePath() {
         // Find a custom report path defined by SONARQUBE_BUILD_REPORT_NAME env var
         // Example: path/custom-report.txt
-        EnvVars envVars = Mockito.spy(new EnvVars());
+        EnvVars envVars = new EnvVars();
 
         SonarQubePointGenerator gen = Mockito.spy(
                 new SonarQubePointGenerator(build,
@@ -207,21 +201,38 @@ public class SonarQubePointGeneratorTest {
         String wsRoot = folder.toString();
 
         try {
-
             String parentCustomDir = customReportPath[customReportPath.length - 1];
             Path customReportPathPattern = Paths.get(parentCustomDir,
                     customReportName);
+            envVars.put("SONARQUBE_BUILD_REPORT_NAME", customReportPathPattern.toString());
 
-            Mockito.doReturn(customReportPathPattern.toString())
-                    .when(envVars)
-                    .get(any(String.class));
-
-            List<Path> result = gen.findReportByFileName(wsRoot);
-            assertEquals(1, result.size());
+            Path result = invokeFindSingleReportPath(gen, Paths.get(wsRoot));
+            assertNotNull(result);
 
         } catch (Exception e) {
             System.err.println("[InfluxDB Plugin Test] ERROR: Failed to find custom report file path - " + e.getMessage());
         }
+    }
+
+    @Test
+    void hasReportFindsCorrectInformationFromBuildArtifact() {
+        File artifactsDir = new File(resourceDirectory, "sonarqube");
+        Mockito.when(build.getArtifactsDir()).thenReturn(artifactsDir);
+
+        EnvVars envVars = new EnvVars();
+        envVars.put("SONARQUBE_BUILD_REPORT_NAME", "report-task.txt");
+        envVars.put("WORKSPACE", "non-existing-workspace");
+
+        SonarQubePointGenerator generator = new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, StringUtils.EMPTY, envVars);
+        boolean hasReport = generator.hasReport();
+
+        String id = "123EXAMPLE";
+        String url = "http://sonarqube:9000";
+        assertTrue(hasReport);
+        assertEquals("InfluxDBPlugin", generator.getProjectKey());
+        assertEquals(url, generator.getSonarBuildURL());
+        assertEquals(id, generator.getSonarBuildTaskId());
+        assertEquals(url + "/api/ce/task?id=" + id, generator.getSonarBuildTaskIdUrl());
     }
 
     @Test
@@ -376,5 +387,11 @@ public class SonarQubePointGeneratorTest {
         method.invoke(generator, "http://default.sonar.url");
 
         Mockito.verify(logger).println("[InfluxDB Plugin] WARNING: No SonarQube auth token found in environment variable SONAR_AUTH_TOKEN. Depending on access rights, this might result in a HTTP/401.");
+    }
+
+    private Path invokeFindSingleReportPath(SonarQubePointGenerator generator, Path rootPath) throws Exception {
+        Method method = SonarQubePointGenerator.class.getDeclaredMethod("findSingleReportPath", Path.class);
+        method.setAccessible(true);
+        return (Path) method.invoke(generator, rootPath);
     }
 }


### PR DESCRIPTION
Feat: Support SonarQube report from archived artifacts

### Problem
I use the InfluxDB Jenkins plugin in an environment with mostly Pipeline jobs, where agents do not share the same workspace filesystem as the controller.
In this setup, SonarQube report discovery in $WORKSPACE can fail, and the resulting exception is swallowed, which forces the plugin to rely on build-log parsing.

### Solution
To make SonarQube report discovery independent of workspace access and less dependent on log parsing, I added a fallback that searches for report-task.txt in archived build artifacts.
This works when artifacts are stored on a controller-accessible filesystem. It does not work with non-filesystem artifact backends (for example, Artifact Manager on S3).

### Testing
Updated and added unit tests for SonarQube report retrieval paths.
Built, deployed, and validated locally on Jenkins with a controller/agent split:
Workspace report available -> workspace path used.
Workspace report unavailable + archived report present -> artifact fallback used.
Neither available -> log parsing fallback used.

## Submitter checklist
- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Describe what you changed
- [ ] Link to relevant issues in GitHub or Jira (N/A if none)
- [ ] Link to relevant pull requests, especially upstream/downstream changes (N/A if none)
- [x] Provide tests that demonstrate the feature works or the issue is fixed