### PR TITLE
Implement measurementRegex

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Optional parameters
 - `customDataTags` (Map) - custom tags in "jenkins_custom_data" measurement
 - `customDataMap` (Map) - custom fields in custom measurements
 - `customDataMapTags` (Map<Map>) - custom tags in custom measurements (map of tags for each custom measurements)
-- `measurementRegex` (String) - optional regex for measurement names to publish; if set, only matching measurement series are published by the call ([default measurement names](doc/available_metrics.md))
+- `measurementRegex` (String) - if set, the call will only publish to measurement names that match the regex ([default measurement names](doc/available_metrics.md))
 - `jenkinsEnvParameterField` (String) - custom fields in "jenkins_data" measurement (newline-separated KEY=VALUE pairs)
 - `jenkinsEnvParameterTag` (String) - custom tags in all measurements (newline-separated KEY=VALUE pairs)
 - `measurementName` (String) - custom measurement name (replaces default "jenkins_data" and "jenkins_custom_data")
@@ -194,21 +194,22 @@ Optional parameters
 All `customData*` parameters contain custom data generated during the
 build and not by the plugin, so they are not available in the snippet generator.
 
-`measurementRegex` filters which measurements are published in a given call.
-This makes it possible to publish multiple distinct rows for the same measurement within a single build by
-calling `influxDbPublisher` multiple times. Note that `target.jobScheduledTimeAsPointsTimestamp` must be
-disabled in this case, as all calls within the same build would otherwise share an identical timestamp, causing InfluxDB to overwrite earlier entries.
+`measurementRegex` (introduced in version 6.1):
+
+This makes it possible to write multiple distinct points to the same measurement within a single job by repeatedly
+calling `influxDbPublisher` and selectively filter to which measurements to publish to. It is recommended to disable `target.jobScheduledTimeAsPointsTimestamp`
+in this case, as all points published by the same job would otherwise share identical timestamps, causing InfluxDB to discard exact duplicates.
 The value is matched against the full measurement name using `java.util.regex.Pattern#matches()`, so use anchors like `^` and `$` for exact matches.
 
-Example: publish only selected measurements using regex.
-The following example publishes only `my_custom_data`, `jenkins_data`, and `git_data`.
+Example: write points to only selected measurement destinations using regex.
+The following example writes points only to the `my_custom_data` and `junit_data` measurements, retaining publication to default measurements like `jenkins_data` and `agent_data`.
 
 ``` syntaxhighlighter-pre
 influxDbPublisher(
   selectedTarget: 'my-target',
   customDataMap: [my_custom_data: [line_rate: 0.92, failures: 2]],
   customDataMapTags: [my_custom_data: [project: 'test-project', trigger: 'darrow']],
-  measurementRegex: '^(my_custom_data|jenkins_data|git_data)$'
+  measurementRegex: '^(my_custom_data|junit_data)$'
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,12 +186,31 @@ Optional parameters
 - `customDataTags` (Map) - custom tags in "jenkins_custom_data" measurement
 - `customDataMap` (Map) - custom fields in custom measurements
 - `customDataMapTags` (Map<Map>) - custom tags in custom measurements (map of tags for each custom measurements)
+- `measurementRegex` (String) - optional regex for measurement names to publish; if set, only matching measurement series are published by the call ([default measurement names](doc/available_metrics.md))
 - `jenkinsEnvParameterField` (String) - custom fields in "jenkins_data" measurement (newline-separated KEY=VALUE pairs)
 - `jenkinsEnvParameterTag` (String) - custom tags in all measurements (newline-separated KEY=VALUE pairs)
 - `measurementName` (String) - custom measurement name (replaces default "jenkins_data" and "jenkins_custom_data")
 
 All `customData*` parameters contain custom data generated during the
 build and not by the plugin, so they are not available in the snippet generator.
+
+`measurementRegex` filters which measurements are published in a given call.
+This makes it possible to publish multiple distinct rows for the same measurement within a single build by
+calling `influxDbPublisher` multiple times. Note that `target.jobScheduledTimeAsPointsTimestamp` must be
+disabled in this case, as all calls within the same build would otherwise share an identical timestamp, causing InfluxDB to overwrite earlier entries.
+The value is matched against the full measurement name using `java.util.regex.Pattern#matches()`, so use anchors like `^` and `$` for exact matches.
+
+Example: publish only selected measurements using regex.
+The following example publishes only `my_custom_data`, `jenkins_data`, and `git_data`.
+
+``` syntaxhighlighter-pre
+influxDbPublisher(
+  selectedTarget: 'my-target',
+  customDataMap: [my_custom_data: [line_rate: 0.92, failures: 2]],
+  customDataMapTags: [my_custom_data: [project: 'test-project', trigger: 'darrow']],
+  measurementRegex: '^(my_custom_data|jenkins_data|git_data)$'
+)
+```
 
 
 > :heavy_exclamation_mark: NOTE! Up to release 1.10.3, pipeline was configured with using the url and database.

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -318,9 +318,9 @@ public class InfluxDbPublicationService {
         listener.getLogger().println("[InfluxDB Plugin] Completed.");
     }
 
-    private List<AbstractPoint> filterByMeasurementRegex(List<AbstractPoint> pointsToWrite, TaskListener listener) {
+    private List<AbstractPoint> filterByMeasurementRegex(List<AbstractPoint> unfiltered, TaskListener listener) {
         if (measurementRegex == null || measurementRegex.trim().isEmpty()) {
-            return pointsToWrite;
+            return unfiltered;
         }
 
         final Pattern pattern;
@@ -336,17 +336,58 @@ public class InfluxDbPublicationService {
             return Collections.emptyList();
         }
 
-        List<AbstractPoint> filtered = pointsToWrite.stream()
+        List<AbstractPoint> filtered = unfiltered.stream()
                 .filter(point -> pattern.matcher(point.getName()).matches())
                 .collect(Collectors.toList());
 
+        Map<String, Long> allCounts = groupMeasurementCounts(unfiltered);
+        Map<String, Long> includedCounts = groupMeasurementCounts(filtered);
+        Map<String, Long> excludedCounts = subtractCounts(allCounts, includedCounts);
+
         listener.getLogger().println(String.format(
-                "[InfluxDB Plugin] measurementRegex active: publishing %d/%d point(s) matching regex '%s'",
-                filtered.size(),
-                pointsToWrite.size(),
+                "[InfluxDB Plugin] measurementRegex active: '%s'",
                 measurementRegex));
+        listener.getLogger().println(String.format(
+                "[InfluxDB Plugin] Publishing points to %d measurement(s): %s",
+                includedCounts.size(),
+                formatMeasurementList(includedCounts)));
+        listener.getLogger().println(String.format(
+                "[InfluxDB Plugin] Excluding points for %d measurement(s): %s",
+                excludedCounts.size(),
+                formatMeasurementList(excludedCounts)));
 
         return filtered;
+    }
+
+    private Map<String, Long> groupMeasurementCounts(List<AbstractPoint> points) {
+        return points.stream()
+                .collect(Collectors.groupingBy(AbstractPoint::getName, TreeMap::new, Collectors.counting()));
+    }
+
+    private Map<String, Long> subtractCounts(Map<String, Long> allCounts, Map<String, Long> includedCounts) {
+        Map<String, Long> excludedCounts = new TreeMap<>(allCounts);
+        includedCounts.forEach((name, count) -> {
+            long remaining = excludedCounts.getOrDefault(name, 0L) - count;
+            if (remaining <= 0) {
+                excludedCounts.remove(name);
+            } else {
+                excludedCounts.put(name, remaining);
+            }
+        });
+        return excludedCounts;
+    }
+
+    private String formatMeasurementList(Map<String, Long> measurementCounts) {
+        if (measurementCounts.isEmpty()) {
+            return "(none)";
+        }
+
+        return measurementCounts.entrySet().stream()
+                .map(entry -> {
+                    String suffix = entry.getValue() > 1 ? String.format(" (%d points)", entry.getValue()) : "";
+                    return entry.getKey() + suffix;
+                })
+                .collect(Collectors.joining(", "));
     }
 
     private void addPointsFromPlugin(List<AbstractPoint> pointsToWrite, PointGenerator generator, TaskListener listener, String plugin) {

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -23,6 +23,8 @@ import java.net.URL;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 public class InfluxDbPublicationService {
@@ -119,6 +121,12 @@ public class InfluxDbPublicationService {
     private final Map<String, Map<String, String>> customDataMapTags;
 
     /**
+     * Optional measurement name regex.
+     * If null or blank, all collected points are published.
+     */
+    private final String measurementRegex;
+
+    /**
      * Jenkins parameter(s) which will be added as field set to measurement 'jenkins_data'.
      * If parameter value has a $-prefix, it will be resolved from current Jenkins job environment properties.
      */
@@ -143,7 +151,7 @@ public class InfluxDbPublicationService {
 
     private final long timestamp;
 
-    public InfluxDbPublicationService(List<Target> selectedTargets, String customProjectName, String customPrefix, Map<String, Object> customData, Map<String, String> customDataTags, Map<String, Map<String, String>> customDataMapTags, Map<String, Map<String, Object>> customDataMap, long timestamp, String jenkinsEnvParameterField, String jenkinsEnvParameterTag, String measurementName) {
+    public InfluxDbPublicationService(List<Target> selectedTargets, String customProjectName, String customPrefix, Map<String, Object> customData, Map<String, String> customDataTags, Map<String, Map<String, String>> customDataMapTags, Map<String, Map<String, Object>> customDataMap, String measurementRegex, long timestamp, String jenkinsEnvParameterField, String jenkinsEnvParameterTag, String measurementName) {
         this.selectedTargets = selectedTargets;
         this.customProjectName = customProjectName;
         this.customPrefix = customPrefix;
@@ -151,6 +159,7 @@ public class InfluxDbPublicationService {
         this.customDataTags = customDataTags;
         this.customDataMap = customDataMap;
         this.customDataMapTags = customDataMapTags;
+        this.measurementRegex = measurementRegex;
         this.timestamp = timestamp;
         this.jenkinsEnvParameterField = jenkinsEnvParameterField;
         this.jenkinsEnvParameterTag = jenkinsEnvParameterTag;
@@ -249,6 +258,8 @@ public class InfluxDbPublicationService {
             logger.fine("Plugin skipped: Coverage");
         }
 
+        pointsToWrite = filterByMeasurementRegex(pointsToWrite, listener);
+
         for (Target target : selectedTargets) {
             try {
                 new URL(target.getUrl());
@@ -305,6 +316,37 @@ public class InfluxDbPublicationService {
         }
 
         listener.getLogger().println("[InfluxDB Plugin] Completed.");
+    }
+
+    private List<AbstractPoint> filterByMeasurementRegex(List<AbstractPoint> pointsToWrite, TaskListener listener) {
+        if (measurementRegex == null || measurementRegex.trim().isEmpty()) {
+            return pointsToWrite;
+        }
+
+        final Pattern pattern;
+        try {
+            pattern = Pattern.compile(measurementRegex.trim());
+        } catch (PatternSyntaxException e) {
+            listener.getLogger().println(String.format(
+                    "[InfluxDB Plugin] Invalid measurementRegex '%s': %s",
+                    measurementRegex,
+                    e.getMessage()));
+            listener.getLogger().println(
+                    "[InfluxDB Plugin] Publishing 0 point(s).");
+            return Collections.emptyList();
+        }
+
+        List<AbstractPoint> filtered = pointsToWrite.stream()
+                .filter(point -> pattern.matcher(point.getName()).matches())
+                .collect(Collectors.toList());
+
+        listener.getLogger().println(String.format(
+                "[InfluxDB Plugin] measurementRegex active: publishing %d/%d point(s) matching regex '%s'",
+                filtered.size(),
+                pointsToWrite.size(),
+                measurementRegex));
+
+        return filtered;
     }
 
     private void addPointsFromPlugin(List<AbstractPoint> pointsToWrite, PointGenerator generator, TaskListener listener, String plugin) {

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -38,6 +38,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
     private Map<String, String> customDataTags;
     private Map<String, Map<String, Object>> customDataMap;
     private Map<String, Map<String, String>> customDataMapTags;
+    private String measurementRegex;
     private String jenkinsEnvParameterField;
     private String jenkinsEnvParameterTag;
     private String measurementName;
@@ -118,6 +119,15 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
     @DataBoundSetter
     public void setCustomDataMapTags(Map<String, Map<String, String>> customDataMapTags) {
         this.customDataMapTags = customDataMapTags;
+    }
+
+    public String getMeasurementRegex() {
+        return measurementRegex;
+    }
+
+    @DataBoundSetter
+    public void setMeasurementRegex(String measurementRegex) {
+        this.measurementRegex = measurementRegex;
     }
 
     public String getJenkinsEnvParameterField() {
@@ -218,6 +228,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
                 customDataTags,
                 customDataMapTags,
                 customDataMap,
+                measurementRegex,
                 currTime,
                 jenkinsEnvParameterField,
                 jenkinsEnvParameterTag,

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStep.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStep.java
@@ -32,6 +32,7 @@ public class InfluxDbStep extends Step {
     private Map<String, String> customDataTags;
     private Map<String, Map<String, Object>> customDataMap;
     private Map<String, Map<String, String>> customDataMapTags;
+    private String measurementRegex;
     private String jenkinsEnvParameterField;
     private String jenkinsEnvParameterTag;
     private String measurementName;
@@ -110,6 +111,15 @@ public class InfluxDbStep extends Step {
     @DataBoundSetter
     public void setCustomDataMapTags(Map<String, Map<String, String>> customDataMapTags) {
         this.customDataMapTags = customDataMapTags;
+    }
+
+    public String getMeasurementRegex() {
+        return measurementRegex;
+    }
+
+    @DataBoundSetter
+    public void setMeasurementRegex(String measurementRegex) {
+        this.measurementRegex = measurementRegex;
     }
 
     public String getJenkinsEnvParameterField() {

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStepExecution.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStepExecution.java
@@ -26,6 +26,7 @@ public class InfluxDbStepExecution extends SynchronousNonBlockingStepExecution<V
         publisher.setCustomData(step.getCustomData());
         publisher.setCustomDataMap(step.getCustomDataMap());
         publisher.setCustomDataMapTags(step.getCustomDataMapTags());
+        publisher.setMeasurementRegex(step.getMeasurementRegex());
         publisher.setCustomDataTags(step.getCustomDataTags());
         publisher.setCustomPrefix(step.getCustomPrefix());
         publisher.setCustomProjectName(step.getCustomProjectName());

--- a/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/global/GlobalRunListener.java
@@ -65,6 +65,7 @@ public class GlobalRunListener extends RunListener<Run<?, ?>> {
                     null,
                     null,
                     null,
+                    null,
                     System.currentTimeMillis() * 1000000,
                     env.expand(env.get(VARIABLE_PREFIX + "CUSTOM_FIELDS")),
                     env.expand(env.get(VARIABLE_PREFIX + "CUSTOM_TAGS")),

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbPublisher/config.jelly
@@ -11,6 +11,9 @@
         <f:entry title="Custom Project Name" field="customProjectName">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Measurement Regex" field="measurementRegex">
+            <f:textbox/>
+        </f:entry>
         <f:entry title="Jenkins Environment Field Set" field="jenkinsEnvParameterField">
             <f:textarea/>
         </f:entry>

--- a/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbStep/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/InfluxDbStep/config.jelly
@@ -11,6 +11,9 @@
         <f:entry title="Custom Project Name" field="customProjectName">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Measurement Regex" field="measurementRegex">
+            <f:textbox/>
+        </f:entry>
         <f:entry title="Jenkins Environment Field Set" field="jenkinsEnvParameterField">
             <f:textarea/>
         </f:entry>

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -78,4 +78,11 @@ class InfluxDbPublisherTest {
         InfluxDbPublisher publisher = new InfluxDbPublisher(null);
         assertEquals(target1, publisher.getTarget());
     }
+
+    @Test
+    void testMeasurementRegexSetterGetter() {
+        InfluxDbPublisher publisher = new InfluxDbPublisher("Target1");
+        publisher.setMeasurementRegex("^(jenkins_data|my_coverage_data)$");
+        assertEquals("^(jenkins_data|my_coverage_data)$", publisher.getMeasurementRegex());
+    }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/IntegrationTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/IntegrationTest.java
@@ -1,5 +1,9 @@
 package jenkinsci.plugins.influxdb;
 
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.QueryApi;
+import com.influxdb.query.FluxTable;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
@@ -95,4 +99,63 @@ public class IntegrationTest extends IntegrationBaseTest {
         this.assertInfluxRecordsAreIdentical(influxData.get(1), expectedValues, ignoreKeys);
         this.assertInfluxRecordsAreIdentical(influxData.get(2), expectedValues, ignoreKeys);
     }
+
+        @Test
+        public void testMeasurementRegexAppliesToPublisherCall() throws Exception {
+                String projectName = "influxdb-regex-test-job-" + System.currentTimeMillis();
+                InfluxDbGlobalConfig globalConfig = InfluxDbGlobalConfig.getInstance();
+                Map<String, Boolean> originalGlobalListenerFlags = new HashMap<>();
+
+                for (Target target : globalConfig.getTargets()) {
+                        originalGlobalListenerFlags.put(target.getDescription(), target.isGlobalListener());
+                        target.setGlobalListener(false);
+                }
+
+                FreeStyleProject project = jenkinsRule.createFreeStyleProject(projectName);
+                project.getBuildersList().add(new Shell("echo 'Measurement regex integration test'"));
+
+                InfluxDbPublisher publisher = new InfluxDbPublisher("InfluxDB v1");
+                publisher.setMeasurementRegex("^jenkins_data$");
+                project.getPublishersList().add(publisher);
+
+                try {
+                        FreeStyleBuild build = project.scheduleBuild2(0).get();
+                        jenkinsRule.assertBuildStatus(Result.SUCCESS, build);
+
+                        try (InfluxDBClient v1Client = InfluxDBClientFactory.createV1(
+                                        testEnv.get("INFLUXDB_V1_URL"),
+                                        testEnv.get("INFLUXDB_USERNAME"),
+                                        testEnv.get("INFLUXDB_PASSWORD").toCharArray(),
+                                        testEnv.get("INFLUXDB_DATABASE_OR_BUCKET"),
+                                        null
+                        )) {
+                                assertEquals(1L, countRecordsForProject(v1Client, "jenkins_data", projectName));
+                                assertEquals(0L, countRecordsForProject(v1Client, "metrics_data", projectName));
+                                assertEquals(0L, countRecordsForProject(v1Client, "agent_data", projectName));
+                        }
+                } finally {
+                        for (Target target : globalConfig.getTargets()) {
+                                Boolean original = originalGlobalListenerFlags.get(target.getDescription());
+                                if (original != null) {
+                                        target.setGlobalListener(original);
+                                }
+                        }
+                }
+        }
+
+        private long countRecordsForProject(InfluxDBClient client, String measurementName, String projectName) {
+                QueryApi queryApi = client.getQueryApi();
+                String flux = String.format(
+                                "from(bucket: \"%s\") " +
+                                                "|> range(start: 0) " +
+                                                "|> filter(fn: (r) => r._measurement == \"%s\")" +
+                                                "|> filter(fn: (r) => r.project_name == \"%s\")" +
+                                                "|> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+                                testEnv.get("INFLUXDB_DATABASE_OR_BUCKET"),
+                                measurementName,
+                                projectName
+                );
+                List<FluxTable> tables = queryApi.query(flux);
+                return tables.stream().mapToLong(table -> table.getRecords().size()).sum();
+        }
 }


### PR DESCRIPTION
Feat: Implement measurementRegex

### Problem
On our Jenkins setup (mostly Pipeline jobs, agent/controller workspace separation), some jobs need multiple publish calls during execution, including multiple rows for the same measurement name.

Before this change, each publish call also emitted the plugin’s default automatic measurements.
That meant if you published multiple times in one build to append data for the same measurement, you had to accept duplicated default measurements (for example jenkins_data, metrics_data, agent_data), which made the result noisy and hard to use.

### Solution
This change adds measurementRegex so each publish call can control exactly which measurements are written.

This enables:

Multiple publishes for the same measurement within one build.
Avoiding duplicate default measurements on intermediate publish calls.
A clean split where intermediate calls publish only targeted custom data, while end-of-build automatic measurements can still come from the listener/final publish path.

This is not the most advanced design, but it provides an uncomplicated and practical option that solves the publishing-duplication problem.

### Testing
Added and updated tests for measurementRegex configuration and behavior.
Built, deployed, and validated locally against InfluxDB.

#### Specific verification performed
Checked empty, invalid, and valid regex patterns.
Verified only intended measurements are written per call.
Verified consecutive publishes to the same measurement no longer force duplicated default measurement output when filtered appropriately.

## Submitter checklist
- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Describe what you changed
- [ ] Link to relevant issues in GitHub or Jira (N/A if none)
- [ ] Link to relevant pull requests, especially upstream/downstream changes (N/A if none)
- [x] Provide tests that demonstrate the feature works or the issue is fixed